### PR TITLE
Reference cleanup

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -16,7 +16,7 @@ We present solutions to these challenges based on our recent experience leading 
 Our review attracted 27 authors from 20 different institutions who were not determined in advance.
 We wrote entirely in the open without restrictions on who was welcome to contribute.
 Although we requested that some authors participate for their specific expertise, most discovered the manuscript organically through conferences or social media and independently decided to contribute.
-To coordinate this effort, we developed a manuscript writing process using the Markdown language, the [GitHub software development platform](https://github.com/greenelab/deep-review/), and our new [Manubot ](https://github.com/greenelab/manubot) tool for automating manuscript generation.
+To coordinate this effort, we developed a manuscript writing process using the Markdown language, the [GitHub software development platform](https://github.com/greenelab/deep-review/), and our new [Manubot](https://github.com/greenelab/manubot) tool for automating manuscript generation.
 
 ### Manubot
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -7,7 +7,7 @@ Open research – which includes sharing code, data, and manuscripts – benefit
 Here we describe the benefits of writing review articles openly, where the planning, organizing, writing, and editing occur collaboratively in a public forum where participants are free to join as they wish.
 Reviews presenting the state of the art in a scientific field are often prepared by a single research group or a small team of colleagues.
 In contrast, broadly opening the writing process to anyone engaged in the topic can help maximize the review's value by facilitating the representation of diverse opinions and the broad coverage of relevant research.
-Review authors can engage with the authors of original research to clarify their methods and results and present them accurately (for example, @url:https://github.com/greenelab/deep-review/issues/213).
+Review authors can engage with the authors of original research to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
 `TODO: need archival issue link`
 In addition, discussing manuscripts in the open provides one form of pre- and post-publication peer review `TODO: define this or provide a reference?`, incentivizing the reviews with potential manuscript authorship.
 However, inviting wide authorship brings many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
@@ -16,7 +16,7 @@ We present solutions to these challenges based on our recent experience leading 
 Our review attracted 27 authors from 20 different institutions who were not determined in advance.
 We wrote entirely in the open without restrictions on who was welcome to contribute.
 Although we requested that some authors participate for their specific expertise, most discovered the manuscript organically through conferences or social media and independently decided to contribute.
-To coordinate this effort, we developed a manuscript writing process using the Markdown language, the GitHub software development platform [@url:https://github.com/greenelab/deep-review/], and our new Manubot tool [@url:https://github.com/greenelab/manubot] for automating manuscript generation.
+To coordinate this effort, we developed a manuscript writing process using the Markdown language, the [GitHub software development platform](https://github.com/greenelab/deep-review/), and our new [Manubot ](https://github.com/greenelab/manubot) tool for automating manuscript generation.
 
 ### Manubot
 
@@ -75,7 +75,7 @@ An [example repository](https://github.com/greenelab/manubot-rootstock) demonstr
 
 ### Contribution workflow
 
-There are many existing collaborative writing platforms ranging from rich text editors, which support Microsoft Word documents or similar formats, to LaTeX-based systems for more technical writing [@doi:10.1038/514127a; @url:https://www.overleaf.com/; @url:https://www.authorea.com/].
+There are many existing collaborative writing platforms ranging from rich text editors, which support Microsoft Word documents or similar formats, to LaTeX-based systems for  technical writing [@doi:10.1038/514127a] such as [Overleaf](https://www.overleaf.com/) and [Authorea](https://www.authorea.com/).
 These platforms ideally offer version control, multiple permission levels, or other functionality to support multi-author document editing.
 Although they work well for editing, they lack sufficient features for managing a collaborative manuscript and attributing precise credit, which are important for open writing.
 
@@ -99,13 +99,13 @@ The entire process can be orchestrated through GitHub with a web browser if a co
 We found that this workflow was an effective compromise between fully unrestricted editing and a more heavily-structured approach that limits the authors or the sections they can edit.
 In addition, authors are associated with their commits, which makes it easy for contributors to receive credit for their work and helps prevent ghostwriting [@doi:10.1371/journal.pmed.1000023].
 The GitHub contributors page summarizes all edits and commits from each author, providing aggregated information that is not available on other collaborative writing platforms.
-Because our writing process, like others backed by the open git version control system [@url:https://www.overleaf.com/; @url:https://www.authorea.com/], tracks the complete commit history, it also enables detailed retrospective contribution analysis.
+Because our writing process, like others backed by the open git version control system (including Overleaf and Authorea), tracks the complete commit history, it also enables detailed retrospective contribution analysis.
 `TODO: confirm Overleaf and Authorea provide this type of git integration versus something more coarse`
 
 ### Authorship
 
-To determine authorship we followed the International Committee of Medical Journal Editors (ICMJE) guidelines and used GitHub to track contributions.
-ICMJE recommends authors substantially contribute to, draft, approve, and agree to be accountable for the manuscript [@url:http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html].
+To determine authorship we followed the [International Committee of Medical Journal Editors (ICMJE) guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) and used GitHub to track contributions.
+ICMJE recommends authors substantially contribute to, draft, approve, and agree to be accountable for the manuscript.
 We acknowledged other contributors who did not meet all four criteria, including contributors who provided text but did not review and approve the complete manuscript.
 Although these criteria provided a straightforward, equitable way to determine who would be an author, they did not produce a traditionally ordered author list.
 In biomedical journals, the convention is that the first and last authors made the most substantial contributions to the manuscript.
@@ -128,7 +128,7 @@ Many others have embraced open science principles and piloted open approaches to
 `TODO: more ideas in doi:10.7287/peerj.preprints.2711v2`
 Several of these open science efforts are GitHub-based like our collaborative writing process.
 The Journal of Open Source Software [@arxiv:1707.02264] and ReScience [@arxiv:1707.04393] journals rely on GitHub for peer review and hosting.
-`TODO: describe Manubot related work here?` [@doi:10.7717/peerj-cs.112; @url:https://github.com/ewanmellor/gh-publisher]
+`TODO: describe Manubot related work here?` [@doi:10.7717/peerj-cs.112] and https://github.com/ewanmellor/gh-publisher
 
 There are potential limitations of our GitHub-based approach.
 Because our review manuscript pertained to a computational topic, most of the authors had computational backgrounds, including previous experience with version control workflows and GitHub.
@@ -150,7 +150,7 @@ We would encourage the maintainers of similar projects to consider broader codes
 Open writing presents new opportunities for scholarly communication.
 `TODO: reference "paper of the future"? arXiv:1601.02927 doi:10.22541/au.149693987.70506124 doi:10.22541/au.148769949.92783646 http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future`
 Though it is still valuable to have versioned drafts of a review manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.
-After releasing the first version of our collaborative review [@doi:10.1101/142760], six new authors have contributed text and existing authors continue to discuss new literature, creating a living document [@url:https://github.com/greenelab/deep-review/].
+After releasing the first version of our collaborative review [@doi:10.1101/142760], six new authors have contributed text and existing authors continue to discuss new literature, [creating a living document](https://github.com/greenelab/deep-review/).
 `TODO: update new author count before submitting`
 The Manubot system can also facilitate open research [@doi:10.7287/peerj.preprints.3100v1] in addition to review articles.
 `TODO: get permission and add https://slochower.github.io/nonequilibrium-barrier/ https://zietzm.github.io/Vagelos2017/`

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -104,7 +104,7 @@ Because our writing process, like others backed by the open git version control 
 
 ### Authorship
 
-To determine authorship we followed the [International Committee of Medical Journal Editors (ICMJE) guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) and used GitHub to track contributions.
+To determine authorship we followed the International Committee of Medical Journal Editors (ICMJE) [guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) and used GitHub to track contributions.
 ICMJE recommends authors substantially contribute to, draft, approve, and agree to be accountable for the manuscript.
 We acknowledged other contributors who did not meet all four criteria, including contributors who provided text but did not review and approve the complete manuscript.
 Although these criteria provided a straightforward, equitable way to determine who would be an author, they did not produce a traditionally ordered author list.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -16,7 +16,7 @@ We present solutions to these challenges based on our recent experience leading 
 Our review attracted 27 authors from 20 different institutions who were not determined in advance.
 We wrote entirely in the open without restrictions on who was welcome to contribute.
 Although we requested that some authors participate for their specific expertise, most discovered the manuscript organically through conferences or social media and independently decided to contribute.
-To coordinate this effort, we developed a manuscript writing process using the Markdown language, the GitHub software development platform [@url:https://github.com/greenelab/deep-review/], and our new Manubot tool [@url:https://github.com/greenelab/manubot-rootstock; @url:https://github.com/greenelab/manubot] for automating manuscript generation.
+To coordinate this effort, we developed a manuscript writing process using the Markdown language, the GitHub software development platform [@url:https://github.com/greenelab/deep-review/], and our new Manubot tool [@url:https://github.com/greenelab/manubot] for automating manuscript generation.
 
 ### Manubot
 
@@ -71,6 +71,7 @@ One direction Manubot is working towards is end-to-end document reproducibility,
 Already, Manubot is well suited for preserving provenance.
 For example, figures can be specified using versioned URLs that refer to the code that created them.
 In addition, manuscripts can be templated, so that numerical values or tables get inserted directly from the repository that created them.
+An [example repository](https://github.com/greenelab/manubot-rootstock) demonstrates Manubot's features and serves as a template for users to write their own manuscript with Manubot.
 
 ### Contribution workflow
 

--- a/content/03.back-matter.md
+++ b/content/03.back-matter.md
@@ -1,4 +1,0 @@
-## Acknowledgements
-
-`TODO: deep review authors for support in testing this process`
-`TODO: manubot-rootstock contributors`

--- a/content/03.back-matter.md
+++ b/content/03.back-matter.md
@@ -2,5 +2,3 @@
 
 `TODO: deep review authors for support in testing this process`
 `TODO: manubot-rootstock contributors`
-
-## References

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -1,3 +1,8 @@
+## Acknowledgements
+
+`TODO: deep review authors for support in testing this process`
+`TODO: manubot-rootstock contributors`
+
 ## References {.page_break_before}
 
 <!-- Explicitly insert bibliography here -->

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -1,22 +1,78 @@
 [
-{
-  "type": "webpage",
-  "standard_citation": "url:https://github.com/greenelab/manubot-rootstock",
-  "URL": "https://github.com/greenelab/manubot-rootstock",
-  "title": "greenelab/manubot-rootstock GitHub repository",
-  "container-title": "GitHub",
-  "issued": {
-    "date-parts": [
-      [
-        2017
+  {
+    "standard_citation": "url:http://www.niso.org/standards/z39-96-2015/",
+    "type": "webpage",
+    "URL": "http://www.niso.org/standards/z39-96-2015/",
+    "title": "JATS: Journal Article Tag Suite, version 1.1"
+    "issued": {
+      "date-parts": [
+        [
+          2015
+        ]
       ]
+    },
+    "author": [
+      {
+        "family": "National Information Standards Organization"
+      }
     ]
   },
-  "author": [
-    {
-      "given": "Daniel",
-      "family": "Himmelstein"
+  {
+    "standard_citation": "url:https://elifesciences.org/for-the-press/e6038800/elife-supports-development-of-open-technology-stack-for-publishing-reproducible-manuscripts-online",
+    "type": "webpage",
+    "URL": "https://elifesciences.org/for-the-press/e6038800/elife-supports-development-of-open-technology-stack-for-publishing-reproducible-manuscripts-online",
+    "title": "eLife supports development of open technology stack for publishing reproducible manuscripts online",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          9,
+          7
+        ]
+      ]
     }
-  ]
-}
+  },
+  {
+    "standard_citation": "url:https://lgatto.github.io/open-and-open/",
+    "type": "webpage",
+    "URL": "https://lgatto.github.io/open-and-open/",
+    "title": "Open science and open science",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          6,
+          5
+        ]
+      ]
+    },
+    "author": [
+      {
+        "family": "Gatto",
+        "given": "Laurent"
+      }
+    ],
+    "archives": [
+      "http://wayback.archive.org/web/https://lgatto.github.io/open-and-open/"
+    ]
+  },
+  {
+    "standard_citation": "url:https://www.contributor-covenant.org/",
+    "type": "webpage",
+    "URL": "https://www.contributor-covenant.org/",
+    "title": "Contributor Covenant: A Code of Conduct for Open Source Projects",
+    "issued": {
+      "date-parts": [
+        [
+          2014
+        ]
+      ]
+    },
+    "author": [
+      {
+        "family": "Ehmke",
+        "given": "Coraline Ada"
+      }
+    ]
+  }
 ]

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -3,7 +3,7 @@
     "standard_citation": "url:http://www.niso.org/standards/z39-96-2015/",
     "type": "webpage",
     "URL": "http://www.niso.org/standards/z39-96-2015/",
-    "title": "JATS: Journal Article Tag Suite, version 1.1"
+    "title": "JATS: Journal Article Tag Suite, version 1.1",
     "issued": {
       "date-parts": [
         [


### PR DESCRIPTION
I converted URL citations to links as appropriate and manually fixed the CSL for the remaining URL citations.  I also cleaned up a few other things, like our duplicate back matter files.

Closes #11.