### PR TITLE
Add Open Journals and GitHub curation

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -128,7 +128,7 @@ Many others have embraced open science principles and piloted open approaches to
 `TODO: more ideas in doi:10.7287/peerj.preprints.2711v2`
 Several of these open science efforts are GitHub-based like our collaborative writing process.
 The ReScience [@arxiv:1707.04393], the Journal of Open Source Software [@arxiv:1707.02264], and some other [Open Journals](http://www.theoj.org/) rely on GitHub for peer review and hosting.
-GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and scholarly reviews combine literature curation with discussion and interpretation.
+GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and collaborative scholarly reviews combine literature curation with discussion and interpretation.
 `TODO: describe Manubot related work here?` [@doi:10.7717/peerj-cs.112] and https://github.com/ewanmellor/gh-publisher
 
 There are potential limitations of our GitHub-based approach.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -127,7 +127,8 @@ Many others have embraced open science principles and piloted open approaches to
 `TODO: need help deciding what related topics to include here and which references to use, these are arbitrary examples`
 `TODO: more ideas in doi:10.7287/peerj.preprints.2711v2`
 Several of these open science efforts are GitHub-based like our collaborative writing process.
-The Journal of Open Source Software [@arxiv:1707.02264] and ReScience [@arxiv:1707.04393] journals rely on GitHub for peer review and hosting.
+The ReScience [@arxiv:1707.04393], the Journal of Open Source Software [@arxiv:1707.02264], and some other [Open Journals](http://www.theoj.org/) rely on GitHub for peer review and hosting.
+GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and scholarly reviews combine literature curation with discussion and interpretation.
 `TODO: describe Manubot related work here?` [@doi:10.7717/peerj-cs.112] and https://github.com/ewanmellor/gh-publisher
 
 There are potential limitations of our GitHub-based approach.


### PR DESCRIPTION
I modified the discussion to integrate references from #14 and #17.  My initial impression is that The Open Journal of Astrophysics does not use GitHub for peer review and hosting, hence the "some other", but I am not certain.