### PR TITLE
Update Manubot to 38effe8

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ All other files are only available under CC BY 4.0, including:
 
 Except for the following files with different licenses:
 
-+ `build/assets/anchors.js` which is [released](https://www.bryanbraun.com/anchorjs/)
-  under an [MIT License](https://opensource.org/licenses/MIT)
++ `build/assets/anchors.js` which is [released](https://www.bryanbraun.com/anchorjs/) under an [MIT License](https://opensource.org/licenses/MIT)
 
 Please open [an issue](https://github.com/greenelab/manubot-rootstock/issues) for any question related to licensing.

--- a/USAGE.md
+++ b/USAGE.md
@@ -66,6 +66,8 @@ For example, the following will override the figure number to be "S1" and set th
 {#fig:supplement tag="S1" width="5in"}
 ```
 
+We recommend always specifying the width of SVG images (even if just `width="100%"`), since otherwise SVGs may not render properly in the [WeasyPrint](http://weasyprint.org/) PDF export.
+
 ### Citations
 
 Manubot supports Pandoc [citations](http://pandoc.org/MANUAL.html#citations) via `pandoc-citeproc`.

--- a/build/build.sh
+++ b/build/build.sh
@@ -44,13 +44,9 @@ pandoc --verbose \
 
 # Create PDF output
 echo "Exporting PDF manuscript"
-wkhtmltopdf \
-  --quiet \
-  --print-media-type \
-  --margin-top 21 \
-  --margin-bottom 17 \
-  --margin-left 0 \
-  --margin-right 0 \
+weasyprint \
+  --verbose \
+  --presentational-hints \
   webpage/index.html \
   output/manuscript.pdf
 

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -8,7 +8,8 @@ dependencies:
   - anaconda::python=3.6.2
   - anaconda::pyyaml=3.12
   - anaconda::requests=2.14.2
-  - bioconda::wkhtmltopdf=0.12.3
+  - conda-forge::cairo=1.14.6
+  - conda-forge::cffi=1.10.0
   - conda-forge::pandoc=1.19.2
   - conda-forge::watchdog=0.8.3
   - pip:
@@ -24,3 +25,4 @@ dependencies:
     - pysha3==1.0.2
     - python-bitcoinlib==0.8.0
     - requests-cache==0.4.13
+    - weasyprint==0.40

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -23,15 +23,15 @@ on {{date}}.
 {% for author in authors %}
 + **{{author.name}}**<br>
   {%- if author.orcid is defined %}
-    ![ORCID icon](images/orcid.svg){height="13px"}
+    ![ORCID icon](images/orcid.svg){height="13px" width="13px"}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}
   {%- if author.github is defined %}
-    · ![GitHub icon](images/github.svg){height="13px"}
+    · ![GitHub icon](images/github.svg){height="13px" width="13px"}
     [{{author.github}}](https://github.com/{{author.github}})
   {%- endif %}
   {%- if author.twitter is defined %}
-    · ![Twitter icon](images/twitter.svg){height="13px"}
+    · ![Twitter icon](images/twitter.svg){height="13px" width="13px"}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
   {%- endif %}<br>
   <small>


### PR DESCRIPTION
Updates to https://github.com/greenelab/manubot-rootstock/commit/38effe877efc7bd6c6de338f306db2a2a33a5df1.

Switches to WeasyPrint for PDF export.