### PR TITLE
Change timestamp paragraph to aid interpretability

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -110,7 +110,7 @@ We implemented support for [OpenTimestamps](https://opentimestamps.org/) in Manu
 This procedure allows one to retrospectively prove that a manuscript version existed prior to its blockchain-verifiable timestamp [@arxiv:1502.04015v1; @url:https://www.bgcarlisle.com/blog/2014/08/25/proof-of-prespecified-endpoints-in-medical-research-with-the-bitcoin-blockchain/; @url:http://blog.dhimmel.com/irreproducible-timestamps/; @url:http://git.dhimmel.com/bitcoin-whitepaper/].
 For Manubot manuscripts, scientific precedence can now be indisputably established, and timestamps protect against attempts to rewrite a manuscript's history.
 Such timestamping practices help ensure accurate histories, potentially alleviating certain authorship or priority disputes.
-Transactions on the Bitcoin blockchain incur a cost that cannot be readily predicted [@url:https://arstechnica.com/tech-policy/2017/12/bitcoin-fees-are-skyrocketing/].
+Since all bitcoin transactions are competing for limited space on the blockchain, the fees required to send a single transaction can be high.
 OpenTimestamps avoids this fee by encoding many timestamps into a single Bitcoin transaction [@url:https://petertodd.org/2016/opentimestamps-announcement], but there can be a lag of a few hours before the transaction is made.
 We judged this to be suitable for the purposes of scientific writing.
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -103,15 +103,16 @@ When this repository changes, Travis CI [rebuilds](https://travis-ci.org/greenel
 If successful, the output is deployed back to GitHub (to dedicated [`output`](https://github.com/greenelab/meta-review/tree/output) and [`gh-pages`](https://github.com/greenelab/meta-review/tree/gh-pages) branches).
 As a result, https://greenelab.github.io/meta-review stays up to date with the latest HTML manuscript.
 
-Manubot uses [OpenTimestamps](https://opentimestamps.org/) to timestamp the HTML and PDF outputs on the Bitcoin blockchain before deploying to GitHub.
+The idea of the "priority of discovery" is important to science, and Vale and Hyman [@doi:10.7554/eLife.16931] discuss the importance of both disclosure and validation.
+In their framework, disclosure occurs when a scientific output is released to the world.
+However, for a manuscript that is shared as it is written, being able to establish priority could be challenging.
+We implemented support for [OpenTimestamps](https://opentimestamps.org/) in Manubot to timestamp the HTML and PDF outputs on the Bitcoin blockchain.
 This procedure allows one to retrospectively prove that a manuscript version existed prior to its blockchain-verifiable timestamp [@arxiv:1502.04015v1; @url:https://www.bgcarlisle.com/blog/2014/08/25/proof-of-prespecified-endpoints-in-medical-research-with-the-bitcoin-blockchain/; @url:http://blog.dhimmel.com/irreproducible-timestamps/; @url:http://git.dhimmel.com/bitcoin-whitepaper/].
-The implications for scientific writing are twofold.
-First, scientific precedence can now be indisputably established.
-Second, timestamps can protect against attempts to rewrite a manuscript's history.
-Since timestamps cannot be backdated, alternative histories would have to be created in advance, which is generally infeasible.
-Therefore, timestamping can help ensure accurate manuscript histories, potentially alleviating certain authorship disputes.
-Note that OpenTimestamps is highly scalable and free to use since it encodes many timestamps into a single Bitcoin transaction.
-However, as a result, timestamps are reliant on third-party calendar services until they are upgraded at which point their lineage to the blockchain becomes self-contained.
+For Manubot manuscripts, scientific precedence can now be indisputably established, and timestamps protect against attempts to rewrite a manuscript's history.
+Such timestamping practices help ensure accurate histories, potentially alleviating certain authorship or priority disputes.
+Transactions on the Bitcoin blockchain incur a cost that cannot be readily predicted [@url:https://arstechnica.com/tech-policy/2017/12/bitcoin-fees-are-skyrocketing/].
+OpenTimestamps avoids this fee by encoding many timestamps into a single Bitcoin transaction[@url:https://petertodd.org/2016/opentimestamps-announcement], but there can be a lag of a few hours before the transaction is made.
+We judged this to be suitable for the purposes of scientific writing.
 
 We designed Manubot to power the next generation of scholarly manuscript.
 Manubot transforms publication, making it permissionless, reproducible, free of charge, and largely open source.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -103,7 +103,7 @@ When this repository changes, Travis CI [rebuilds](https://travis-ci.org/greenel
 If successful, the output is deployed back to GitHub (to dedicated [`output`](https://github.com/greenelab/meta-review/tree/output) and [`gh-pages`](https://github.com/greenelab/meta-review/tree/gh-pages) branches).
 As a result, https://greenelab.github.io/meta-review stays up to date with the latest HTML manuscript.
 
-The idea of the "priority of discovery" is important to science, and Vale and Hyman [@doi:10.7554/eLife.16931] discuss the importance of both disclosure and validation.
+The idea of the "priority of discovery" is important to science, and Vale and Hyman discuss the importance of both disclosure and validation [@doi:10.7554/eLife.16931].
 In their framework, disclosure occurs when a scientific output is released to the world.
 However, for a manuscript that is shared as it is written, being able to establish priority could be challenging.
 We implemented support for [OpenTimestamps](https://opentimestamps.org/) in Manubot to timestamp the HTML and PDF outputs on the Bitcoin blockchain.
@@ -111,7 +111,7 @@ This procedure allows one to retrospectively prove that a manuscript version exi
 For Manubot manuscripts, scientific precedence can now be indisputably established, and timestamps protect against attempts to rewrite a manuscript's history.
 Such timestamping practices help ensure accurate histories, potentially alleviating certain authorship or priority disputes.
 Transactions on the Bitcoin blockchain incur a cost that cannot be readily predicted [@url:https://arstechnica.com/tech-policy/2017/12/bitcoin-fees-are-skyrocketing/].
-OpenTimestamps avoids this fee by encoding many timestamps into a single Bitcoin transaction[@url:https://petertodd.org/2016/opentimestamps-announcement], but there can be a lag of a few hours before the transaction is made.
+OpenTimestamps avoids this fee by encoding many timestamps into a single Bitcoin transaction [@url:https://petertodd.org/2016/opentimestamps-announcement], but there can be a lag of a few hours before the transaction is made.
 We judged this to be suitable for the purposes of scientific writing.
 
 We designed Manubot to power the next generation of scholarly manuscript.


### PR DESCRIPTION
A couple things:

* Doh! I cloned the greenelab repo so this is going to create a branch we'll need to prune.
* I tried to provide a bit of context around the need for timestamps.
* I tried to make the section interpretable to someone who is a part of the blockchain lay audience.

This would close #32 