### PR TITLE
Add citation examples table

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -19,7 +19,7 @@ Although we invited some specific experts to participate, most authors discovere
 In total, the Deep Review attracted {{deep_review_authors}} authors who were not determined in advance from 20 different institutions.
 
 Writing review articles in a public forum allows review authors to engage with the original researchers to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
-Additionally, discussing manuscripts in the open generates valuable post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063] or pre-publication peer review of preprints [@doi:10.7554/eLife.38532].
+Additionally, discussing manuscripts in the open generates valuable post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063] or pre-publication peer review of preprints [@tag:Avasthi2018_preprints].
 Because incentives are commonly lacking to provide public peer review of existing literature [@doi:10.1629/uksg.245], open collaborative reviews --- where authorship is open to anyone who makes a valid contribution --- could help spur more post-publication peer review.
 However, inviting wide authorship brings many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
 
@@ -85,9 +85,11 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 | PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) | `pmcid:PMC4719068` | [@pmcid:PMC4719068] |
 | arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) | `arxiv:1502.04015v1` | [@arxiv:1502.04015v1] |
 | URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] | `url:https://lgatto.github.io/open-and-open/` | [@url:https://lgatto.github.io/open-and-open/] |
-| Tag | Source for tagged identifier |  |  |
+| Tag | Source for tagged identifier | `tag:Avasthi2018_preprints` | [@tag:Avasthi2018_preprints] |
 
 Table: Citation types supported by Manubot.
+Authors map each tag to one of the other supported identifier types.
+In this example, `Avasthi2018_preprints` represents the DOI identifier `doi:10.7554/eLife.38532`.
 {#tbl:citations}
 
 Manubot formats bibliographies according to a [CSL](http://citationstyles.org/) specification.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -2,7 +2,7 @@
 
 Openness in research --- which includes sharing code, data, and manuscripts --- benefits the researchers who practice it [@doi:10.7554/eLife.16800], their scientific peers, and the public.
 `TODO: more references needed`
-Open scholarly writing, a form of crowdsourcing [@doi:10.1093/bib/bbv021], has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].
+Open scholarly writing, a form of crowdsourcing [@pmcid:PMC4719068], has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].
 Literature reviews are typically written in private by a closed team of colleagues.
 In contrast, broadly opening the process to anyone engaged in the topic --- such that planning, organizing, writing, and editing occur collaboratively in a public forum where anyone is welcome to participate --- can maximize a review's value.
 Open drafting of reviews is especially helpful for capturing state-of-the-art knowledge about rapidly advancing research topics at the intersection of existing disciplines where contributors bring diverse opinions and expertise.
@@ -19,7 +19,7 @@ Although we invited some specific experts to participate, most authors discovere
 In total, the Deep Review attracted {{deep_review_authors}} authors who were not determined in advance from 20 different institutions.
 
 Writing review articles in a public forum allows review authors to engage with the original researchers to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
-Additionally, discussing manuscripts in the open generates valuable post-publication peer review [@doi:10.1016/j.tig.2015.03.006; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063] or pre-publication peer review of preprints [@doi:10.7554/eLife.38532].
+Additionally, discussing manuscripts in the open generates valuable post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063] or pre-publication peer review of preprints [@doi:10.7554/eLife.38532].
 Because incentives are commonly lacking to provide public peer review of existing literature [@doi:10.1629/uksg.245], open collaborative reviews --- where authorship is open to anyone who makes a valid contribution --- could help spur more post-publication peer review.
 However, inviting wide authorship brings many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
 
@@ -81,8 +81,8 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 | Identifier | Metadata source | Example citation | Processed citation |
 | --- | --- | --- | --- |
 | Digital Object Identifier (DOI) | DOI [Content Negotiation](https://citation.crosscite.org/docs.html) | `doi:10.1098/rsif.2017.0387` | [@doi:10.1098/rsif.2017.0387] |
-| PubMed Identifier (PMID) | NCBI's [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) |  |  |
-| PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) |  |  |
+| PubMed Identifier (PMID) | NCBI's [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) | `pmid:25851694` | [@pmid:25851694] |
+| PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) | `pmcid:PMC4719068` | [@pmcid:PMC4719068] |
 | arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) | `arxiv:1502.04015v1` | [@arxiv:1502.04015v1] |
 | URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] | `url:https://lgatto.github.io/open-and-open/` | [@url:https://lgatto.github.io/open-and-open/] |
 | Tag | Source for tagged identifier |  |  |

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -80,11 +80,11 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 
 | Identifier | Metadata source | Example citation | Processed citation |
 | --- | --- | --- | --- |
-| Digital Object Identifier (DOI) | DOI [Content Negotiation](https://citation.crosscite.org/docs.html) | | |
+| Digital Object Identifier (DOI) | DOI [Content Negotiation](https://citation.crosscite.org/docs.html) | `doi:10.1098/rsif.2017.0387` | [@doi:10.1098/rsif.2017.0387] |
 | PubMed Identifier (PMID) | NCBI's [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) |  |  |
 | PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) |  |  |
-| arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) |  |  |
-| URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] |  |  |
+| arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) | `arxiv:1502.04015v1` | [@arxiv:1502.04015v1] |
+| URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] | `url:https://lgatto.github.io/open-and-open/` | [@url:https://lgatto.github.io/open-and-open/] |
 | Tag | Source for tagged identifier |  |  |
 
 Table: Citation types supported by Manubot.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -73,12 +73,24 @@ In addition, Manubot relies on extensions from [Pandoc markdown](https://pandoc.
 
 Manubot includes an additional layer of citation processing, currently unique to the system.
 All citations point to a standard identifier, for which Manubot automatically retrieves bibliographic metadata.
-Currently, citations to DOIs (Digital Object Identifiers), PubMed or PubMed Central identifiers, arXiv identifiers, and URLs (web addresses) are supported.
-Metadata is retrieved using DOI [Content Negotiation](https://citation.crosscite.org/docs.html), NCBI's [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) and [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/), the [arXiv API](https://arxiv.org/help/api/index), and [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1].
-Metadata is exported to [CSL JSON Items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items), an open standard that's widely supported by reference managers [@doi:10.1007/978-3-319-00026-8_8; @doi:10.1080/02763869.2012.641841].
+Table @tbl:citations presents the supported identifiers and example citations before and after Manubot processing.
+Authors can optionally define citation tags to provide short readable alternatives to the citation identifiers.
+Metadata is exported to [Citation Style Language (CSL) JSON Items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items), an open standard that's widely supported by reference managers [@doi:10.1007/978-3-319-00026-8_8; @doi:10.1080/02763869.2012.641841].
 In cases where automatic retrieval of metadata fails or produces incorrect references --- which is most common for URL citations --- users can manually provide the correct CSL JSON.
 
-The Manubot formats bibliographies according to a [Citation Style Language](http://citationstyles.org/) (CSL) specification.
+| Identifier | Metadata source | Example citation | Processed citation |
+| --- | --- | --- | --- |
+| Digital Object Identifier (DOI) | DOI [Content Negotiation](https://citation.crosscite.org/docs.html) | | |
+| PubMed Identifier (PMID) | NCBI's [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) |  |  |
+| PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) |  |  |
+| arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) |  |  |
+| URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] |  |  |
+| Tag | Source for tagged identifier |  |  |
+
+Table: Citation types supported by Manubot.
+{#tbl:citations}
+
+Manubot formats bibliographies according to a [CSL](http://citationstyles.org/) specification.
 As a result, users can choose from thousands of existing CSL styles or use Manubot's default style.
 Styles define how references are constructed from bibliographic metadata, controlling layout details such as the max number of authors to list per reference.
 Thousands of journals have [predefined styles](http://editor.citationstyles.org/searchByName/).

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -88,7 +88,7 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 | Tag | Source for tagged identifier | `tag:Avasthi2018_preprints` | [@tag:Avasthi2018_preprints] |
 
 Table: Citation types supported by Manubot.
-Authors map each tag to one of the other supported identifier types.
+Authors may optionally map each tag to one of the other supported identifier types.
 In this example, `Avasthi2018_preprints` represents the DOI identifier `doi:10.7554/eLife.38532`.
 {#tbl:citations}
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -75,7 +75,7 @@ Manubot includes an additional layer of citation processing, currently unique to
 All citations point to a standard identifier, for which Manubot automatically retrieves bibliographic metadata.
 Table @tbl:citations presents the supported identifiers and example citations before and after Manubot processing.
 Authors can optionally define citation tags to provide short readable alternatives to the citation identifiers.
-Metadata is exported to [Citation Style Language (CSL) JSON Items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items), an open standard that's widely supported by reference managers [@doi:10.1007/978-3-319-00026-8_8; @doi:10.1080/02763869.2012.641841].
+Metadata is exported to [Citation Style Language (CSL) JSON Items](http://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#items), an open standard that is widely supported by reference managers [@doi:10.1007/978-3-319-00026-8_8; @doi:10.1080/02763869.2012.641841].
 In cases where automatic retrieval of metadata fails or produces incorrect references --- which is most common for URL citations --- users can manually provide the correct CSL JSON.
 
 | Identifier | Metadata source | Example citation | Processed citation |
@@ -94,7 +94,7 @@ In this example, `Avasthi2018_preprints` represents the DOI identifier `doi:10.7
 
 Manubot formats bibliographies according to a [CSL](http://citationstyles.org/) specification.
 As a result, users can choose from thousands of existing CSL styles or use Manubot's default style.
-Styles define how references are constructed from bibliographic metadata, controlling layout details such as the max number of authors to list per reference.
+Styles define how references are constructed from bibliographic metadata, controlling layout details such as the maximum number of authors to list per reference.
 Thousands of journals have [predefined styles](http://editor.citationstyles.org/searchByName/).
 As a result, adopting the specific bibliographic format required by a journal usually just requires specifying the style's source URL in the Manubot configuration.
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -88,8 +88,8 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 | Tag | Source for tagged identifier | `tag:Avasthi2018_preprints` | [@tag:Avasthi2018_preprints] |
 
 Table: Citation types supported by Manubot.
-Authors may optionally map each tag to one of the other supported identifier types.
-In this example, `Avasthi2018_preprints` represents the DOI identifier `doi:10.7554/eLife.38532`.
+Authors may optionally map a named tag to one of the other supported identifier types.
+In this example, the tag `Avasthi2018_preprints` represents the DOI identifier `doi:10.7554/eLife.38532`.
 {#tbl:citations}
 
 Manubot formats bibliographies according to a [CSL](http://citationstyles.org/) specification.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -1,2 +1,3 @@
 tag	citation
 techblog	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manubot-powers-a-crowdsourced-deep-learning-review/
+Avasthi2018_preprints	doi:10.7554/eLife.38532


### PR DESCRIPTION
Closes #48.

I did not want to introduce new references for the sake of illustrating PMID and PMCIDs, so I replaced existing DOIs with these identifiers.  As a workaround for escaping `@` , I left it out of the example column.  The table can illustrate the concept without providing the full instructions or syntax.