### PR TITLE
Absolute workflow figure size and fix caption

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -54,7 +54,8 @@ In this example, the contributor opens an issue to discuss a manuscript modifica
 A maintainer and additional participant provide feedback, and the maintainer recommends creating a pull request to update the text.
 The contributor creates the pull request, it is reviewed by a maintainer and a participant, and the contributor updates the pull request in response.
 Once the pull request is approved, the maintainer merges the changes into the official version of the manuscript.
-](images/workflow.svg){#fig:workflow width="75%"}
+](images/workflow.svg){#fig:workflow width=5in}
+
 <!-- Google Drawing View Link https://docs.google.com/drawings/d/17mst0Z1RMXegeGhM6SwQSJ4nhHgMMh5csyV4MwhsgAY/edit?usp=sharing -->
 
 The Deep Review [issue](https://github.com/greenelab/deep-review/issues/575) and [pull request](https://github.com/greenelab/deep-review/pull/638) on protein-protein interactions demonstrate this process in practice.


### PR DESCRIPTION
We needed to have an empty line between the figure and the comment with the Google Drawing link.  Here is my local build with a 5 in absolute width: [manuscript.pdf](https://github.com/greenelab/meta-review/files/2112842/manuscript.pdf)

Closes #61.