### PR TITLE
Remove todos and start future paper discussion

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -1,7 +1,6 @@
 ## Introduction {.page_break_before}
 
 Openness in research --- which includes sharing code, data, and manuscripts --- benefits the researchers who practice it [@doi:10.7554/eLife.16800], their scientific peers, and the public.
-`TODO: more references needed`
 Open scholarly writing, a form of crowdsourcing [@pmcid:PMC4719068], has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].
 Literature reviews are typically written in private by a closed team of colleagues.
 In contrast, broadly opening the process to anyone engaged in the topic --- such that planning, organizing, writing, and editing occur collaboratively in a public forum where anyone is welcome to participate --- can maximize a review's value.
@@ -68,7 +67,6 @@ We found that this workflow was an effective compromise between fully unrestrict
 In addition, authors are associated with their commits, which makes it easy for contributors to receive credit for their work and helps prevent ghostwriting [@doi:10.1371/journal.pmed.1000023].
 Figure @fig:contrib and the GitHub [contributors page](https://github.com/greenelab/deep-review/graphs/contributors) summarize all edits and commits from each author, providing aggregated information that is not available on other collaborative writing platforms.
 Because our writing process, like others backed by the open git version control system (including Overleaf and Authorea), tracks the complete commit history, it also enables detailed retrospective contribution analysis.
-`TODO: confirm Overleaf and Authorea provide this type of git integration versus something more coarse`
 
 ![
 **Deep Review contributions by author over time.**
@@ -187,8 +185,6 @@ Wikipedia scaled encyclopedias [far beyond](https://en.wikipedia.org/wiki/Wikipe
 As the examples above illustrate, open collaborative writing appears to scale scholarly manuscripts where diverse opinion and expertise are paramount beyond what would otherwise be possible.
 
 Many others have embraced open science principles and piloted open approaches toward drug discovery [@doi:10.7554/eLife.26726; @doi:10.1371/journal.pmed.1002276], data management [@doi:10.1371/journal.pbio.1001195; @doi:10.1038/sdata.2016.18; @doi:10.1038/nbt.3516], and manuscript review [@doi:10.12688/f1000research.12037.1].
-`TODO: need help deciding what related topics to include here and which references to use, these are arbitrary examples`
-`TODO: more ideas in doi:10.7287/peerj.preprints.2711v2`
 Several of these open science efforts are GitHub-based like our collaborative writing process.
 The ReScience [@doi:10.7717/peerj-cs.142], the Journal of Open Source Software [@doi:10.7717/peerj-cs.147], and some other [Open Journals](http://www.theoj.org/) rely on GitHub for peer review and hosting.
 GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and collaborative scholarly reviews combine literature curation with discussion and interpretation.
@@ -212,12 +208,10 @@ Conferences and open source projects have used codes of conduct to establish the
 We would encourage the maintainers of similar projects to consider broader codes of conduct for project participants that establish on social as well as academic norms.
 
 Open writing presents new opportunities for scholarly communication.
-`TODO: reference "paper of the future"? arXiv:1601.02927 doi:10.22541/au.149693987.70506124 doi:10.22541/au.148769949.92783646 http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future`
 Though it is still valuable to have versioned drafts of a review manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.
 After releasing the first version of our collaborative review [@doi:10.1101/142760], {{deep_review_post_submission_authors}} new contributors have updated the manuscript (Figure @fig:contrib) and existing authors continue to discuss new literature, [creating a living document](https://github.com/greenelab/deep-review/).
 `TODO: update new author count before submitting`
 The Manubot system can also facilitate open research [@doi:10.7287/peerj.preprints.3100v1] in addition to review articles.
-`TODO: get permission and add https://slochower.github.io/nonequilibrium-barrier/ https://zietzm.github.io/Vagelos2017/`
 
 Our process represents an early step toward open massively collaborative reviews, and there are certainly aspects that can be improved.
 We invite the scientific community to adapt and build upon our experience and open software.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -6,7 +6,7 @@ Literature reviews are typically written in private by a closed team of colleagu
 In contrast, broadly opening the process to anyone engaged in the topic --- such that planning, organizing, writing, and editing occur collaboratively in a public forum where anyone is welcome to participate --- can maximize a review's value.
 Open drafting of reviews is especially helpful for capturing state-of-the-art knowledge about rapidly advancing research topics at the intersection of existing disciplines where contributors bring diverse opinions and expertise.
 
-Based on our experience leading a recent open review [@tag:techblog], we discuss the pros and cons of open collaborative reviews as well as how they contribute to a living and frequently updated literature.
+Based on our experience leading a recent open review [@tag:techblog_manubot], we discuss the pros and cons of open collaborative reviews as well as how they contribute to a living and frequently updated literature.
 Our review manuscript [@doi:10.1098/rsif.2017.0387], code-named the Deep Review, surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
 In addition, we introduce [Manubot](https://github.com/greenelab/manubot-rootstock), the infrastructure we created to enable open manuscript writing online for Deep Review, which was subsequently adopted by other projects.
 
@@ -183,11 +183,14 @@ The greatest success to date of open collaborative writing is arguably Wikipedia
 Wikipedia scaled encyclopedias [far beyond](https://en.wikipedia.org/wiki/Wikipedia:Size_comparisons) any privately-written alternative.
 As the examples above illustrate, open collaborative writing appears to scale scholarly manuscripts where diverse opinion and expertise are paramount beyond what would otherwise be possible.
 
+Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog_brown].
+Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing.
+Examples of continuous integration to automate manuscript generation include [gh-publisher](https://github.com/ewanmellor/gh-publisher) and Continuous Publishing [@url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/], which was used to produce the book Opening Science [@doi:10.1007/978-3-319-00026-8].
+
 Many others have embraced open science principles and piloted open approaches toward drug discovery [@doi:10.7554/eLife.26726; @doi:10.1371/journal.pmed.1002276], data management [@doi:10.1371/journal.pbio.1001195; @doi:10.1038/sdata.2016.18; @doi:10.1038/nbt.3516], and manuscript review [@doi:10.12688/f1000research.12037.1].
 Several of these open science efforts are GitHub-based like our collaborative writing process.
 The ReScience [@doi:10.7717/peerj-cs.142], the Journal of Open Source Software [@doi:10.7717/peerj-cs.147], and some other [Open Journals](http://www.theoj.org/) rely on GitHub for peer review and hosting.
 GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and collaborative scholarly reviews combine literature curation with discussion and interpretation.
-`TODO: describe Manubot related work here?` [@doi:10.7717/peerj-cs.112] and https://github.com/ewanmellor/gh-publisher
 
 There are potential limitations of our GitHub-based approach.
 Because our review manuscript pertained to a computational topic, most of the authors had computational backgrounds, including previous experience with version control workflows and GitHub.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -169,7 +169,6 @@ A randomized algorithm then arbitrarily ordered authors within each contribution
 The randomization procedure was shared with the authors in advance (pre-registered) and run in a deterministic manner.
 Given the same author contributions, it always produced the same ordered author list.
 We annotated the author list to indicate that author order was partly randomized and emphasize that the order did not indicate one author contributed more than another from the same category.
-`TODO: In Discussion, present alternative author ordering strategies and literature on contribution in collaborative projects`
 
 ## Discussion
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -210,7 +210,6 @@ We would encourage the maintainers of similar projects to consider broader codes
 Open writing presents new opportunities for scholarly communication.
 Though it is still valuable to have versioned drafts of a review manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.
 After releasing the first version of our collaborative review [@doi:10.1101/142760], {{deep_review_post_submission_authors}} new contributors have updated the manuscript (Figure @fig:contrib) and existing authors continue to discuss new literature, [creating a living document](https://github.com/greenelab/deep-review/).
-`TODO: update new author count before submitting`
 The Manubot system can also facilitate open research [@doi:10.7287/peerj.preprints.3100v1] in addition to review articles.
 
 Our process represents an early step toward open massively collaborative reviews, and there are certainly aspects that can be improved.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -1,3 +1,4 @@
 tag	citation
-techblog	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manubot-powers-a-crowdsourced-deep-learning-review/
+techblog_manubot	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manubot-powers-a-crowdsourced-deep-learning-review/
+techblog_brown	url:http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future
 Avasthi2018_preprints	doi:10.7554/eLife.38532


### PR DESCRIPTION
I'm removing several TODOs and using issues to track open items because they better support discussion.  It also makes the current version of the manuscript more readable.  As part of that, I started a Discussion paragraph that closes #30 and includes some references from #47.

The other issues for these TODOs are #44, #45, #66, and #68.