### PR TITLE
Convert 'markdown' to 'Markdown'

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -71,7 +71,7 @@ Because our writing process, like others backed by the open git version control 
 ![
 **Deep Review contributions by author over time.**
 The total words added to the Deep Review by each author is plotted over time (final values in parentheses).
-These statistics were extracted from git commit diffs of the manuscript's markdown source.
+These statistics were extracted from git commit diffs of the manuscript's Markdown source.
 This figure reveals the composition of written contributions to the manuscript at every point in its history.
 Deep Review was initiated in August 2016, and the first complete manuscript was released as a preprint [@doi:10.1101/142760] in May 2017.
 While the article was under review, we continued to maintain the project and accepted new contributions.
@@ -81,9 +81,9 @@ The preprint was updated in January 2018, and the article was accepted by the jo
 ## Manubot
 
 We developed Manubot, a system for writing scholarly manuscripts via GitHub.
-With Manubot, manuscripts are written as plain-text markdown files, which is well suited for version control using git.
-The markdown standard itself provides limited yet crucial formatting syntax, including the ability to embed images and format text via bold, italics, hyperlinks, headers, inline code, codeblocks, blockquotes, and numbered or bulleted lists.
-In addition, Manubot relies on extensions from [Pandoc markdown](https://pandoc.org/MANUAL.html#pandocs-markdown) to enable citations, tables, captions, and equations specified using the popular TeX math syntax.
+With Manubot, manuscripts are written as plain-text Markdown files, which is well suited for version control using git.
+The Markdown standard itself provides limited yet crucial formatting syntax, including the ability to embed images and format text via bold, italics, hyperlinks, headers, inline code, codeblocks, blockquotes, and numbered or bulleted lists.
+In addition, Manubot relies on extensions from [Pandoc Markdown](https://pandoc.org/MANUAL.html#pandocs-Markdown) to enable citations, tables, captions, and equations specified using the popular TeX math syntax.
 
 Manubot includes an additional layer of citation processing, currently unique to the system.
 All citations point to a standard identifier, for which Manubot automatically retrieves bibliographic metadata.
@@ -112,7 +112,7 @@ Styles define how references are constructed from bibliographic metadata, contro
 Thousands of journals have [predefined styles](http://editor.citationstyles.org/searchByName/).
 As a result, adopting the specific bibliographic format required by a journal usually just requires specifying the style's source URL in the Manubot configuration.
 
-Manubot uses [Pandoc](https://pandoc.org/) to convert manuscripts from markdown to HTML, PDF, and optionally DOCX outputs.
+Manubot uses [Pandoc](https://pandoc.org/) to convert manuscripts from Markdown to HTML, PDF, and optionally DOCX outputs.
 Pandoc supports conversion between additional formats — such as LaTeX, AsciiDoc, EPUB, and JATS — offering Manubot users broad interoperability.
 [Journal Article Tag Suite](https://jats.nlm.nih.gov/) (JATS) is a standard XML format for scholarly articles that is used by publishers, archives, and text miners [@url:http://www.niso.org/standards/z39-96-2015/; @doi:10.6087/kcse.2014.1.99; @doi:10.1080/00987913.2012.10765464].
 Going forward, we hope to integrate Manubot with the larger JATS ecosystem.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -83,7 +83,7 @@ The preprint was updated in January 2018, and the article was accepted by the jo
 We developed Manubot, a system for writing scholarly manuscripts via GitHub.
 With Manubot, manuscripts are written as plain-text Markdown files, which is well suited for version control using git.
 The Markdown standard itself provides limited yet crucial formatting syntax, including the ability to embed images and format text via bold, italics, hyperlinks, headers, inline code, codeblocks, blockquotes, and numbered or bulleted lists.
-In addition, Manubot relies on extensions from [Pandoc Markdown](https://pandoc.org/MANUAL.html#pandocs-Markdown) to enable citations, tables, captions, and equations specified using the popular TeX math syntax.
+In addition, Manubot relies on extensions from [Pandoc Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown) to enable citations, tables, captions, and equations specified using the popular TeX math syntax.
 
 Manubot includes an additional layer of citation processing, currently unique to the system.
 All citations point to a standard identifier, for which Manubot automatically retrieves bibliographic metadata.


### PR DESCRIPTION
We agreed in https://github.com/greenelab/meta-review/pull/72#discussion_r201478511 that "Markdown" is the more common spelling. This PR converts existing instances "markdown" to "Markdown."

Note that this also changed a URL and link text. The link text ("Pandoc Markdown") now matches the content of that article, so that's good. The word "markdown" in the URL also changed, but the URL still works, so it seems fine.

```
sed -i 's/markdown/Markdown/g' *.md
```