### PR TITLE
Manually edit two URL references

### DIFF
--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -165,5 +165,49 @@
         "family": "Himmelstein"
       }
     ]
+  },
+  {
+    "standard_citation": "url:http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future",
+    "URL": "http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future/",
+    "title": "TechBlog: C. Titus Brown: Predicting the paper of the future",
+    "container-title": "Naturejobs",
+    "issued": {
+      "date-parts": [
+        [
+          2017,
+          6,
+          1
+        ]
+      ]
+    },
+    "author": [
+      {
+        "given": "C. Titus",
+        "family": "Brown"
+      }
+    ],
+    "type": "post-weblog"
+  },
+  {
+    "type": "webpage",
+    "standard_citation": "url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/",
+    "URL": "http://blog.martinfenner.org/2014/03/10/continuous-publishing/",
+    "title": "Continuous Publishing",
+    "container-title": "Gobbledygook",
+    "issued": {
+      "date-parts": [
+        [
+          2014,
+          3,
+          10
+        ]
+      ]
+    },
+    "author": [
+      {
+        "given": "Martin",
+        "family": "Fenner"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This adds authors for the two URL references added in #69.

@dhimmel another book reference adding in that pull request also has questionable formatting:
> **Opening Science**_Springer International Publishing_ (2014) https://doi.org/10.1007/978-3-319-00026-8

The editors are extracted correctly, but our CSL file does not show book editors.  Do we want to update the CSL or do you prefer this style?