### PR TITLE
Fix typo in slochower metadata

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -24,7 +24,7 @@ author_info:
     orcid: 0000-0003-3928-5050
     twitter: drslochower
     email: slochower@gmail.com
-    affilitations:
+    affiliations:
       - Skaggs School of Pharmacy and Pharmaceutical Sciences, University of California, San Diego
   -
     github: cgreene


### PR DESCRIPTION
I missed this when reviewing #75.  I'll merge once the build passes.