### PR TITLE
Add complementary projects

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -200,6 +200,8 @@ As the examples above illustrate, open collaborative writing appears to scale sc
 Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog_brown].
 Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing.
 Examples of continuous integration to automate manuscript generation include [gh-publisher](https://github.com/ewanmellor/gh-publisher) and Continuous Publishing [@url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/], which was used to produce the book Opening Science [@doi:10.1007/978-3-319-00026-8].
+Distill journal articles [@doi:10.23915/distill.00010], Idyll [@tag:idyll], and Stencila [@tag:stencila] support manuscripts with interactive graphics and close integration with the underlying code.
+As an open source project, Manubot can be extended to adopt best practices from these other emerging platforms.
 
 Many others have embraced open science principles and piloted open approaches toward drug discovery [@doi:10.7554/eLife.26726; @doi:10.1371/journal.pmed.1002276], data management [@doi:10.1371/journal.pbio.1001195; @doi:10.1038/sdata.2016.18; @doi:10.1038/nbt.3516], and manuscript review [@doi:10.12688/f1000research.12037.1].
 Several of these open science efforts are GitHub-based like our collaborative writing process.
@@ -226,6 +228,7 @@ We would encourage the maintainers of similar projects to consider broader codes
 Open writing presents new opportunities for scholarly communication.
 Though it is still valuable to have versioned drafts of a review manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.
 After releasing the first version of our collaborative review [@doi:10.1101/142760], {{deep_review_post_submission_authors}} new contributors have updated the manuscript (Figure @fig:contrib) and existing authors continue to discuss new literature, [creating a living document](https://github.com/greenelab/deep-review/).
+Manubot provides an ideal platform for perpetual reviews [@arxiv:1502.01329; @tag:livecoms].
 
 Our process represents an early step toward open massively collaborative reviews, and there are certainly aspects that can be improved.
 We invite the scientific community to adapt and build upon our experience and open software.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -3,3 +3,6 @@ techblog_manubot	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manu
 techblog_brown	url:http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future
 Avasthi2018_preprints	doi:10.7554/eLife.38532
 steemit-post	url:https://goo.gl/jAcwjm
+idyll	url:https://idyll.pub/post/announcing-idyll-pub-0a3eff0661df3446a915700d/
+stencila	url:https://elifesciences.org/labs/c496b8bb/stencila-an-office-suite-for-reproducible-research
+livecoms	url:http://www.livecomsjournal.org/article/2031-why-we-need-the-living-journal-of-computational-molecular-science


### PR DESCRIPTION
This adds additional related projects from #47.  I did not add all of the projects from the list in #47 so we may want to leave #47 open or close it an create a follow up issue with the remaining projects to consider.