### PR TITLE
Add deep review repository status

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -78,6 +78,7 @@ This figure reveals the composition of written contributions to the manuscript a
 Deep Review was initiated in August 2016, and the first complete manuscript was released as a preprint [@doi:10.1101/142760] in May 2017.
 While the article was under review, we continued to maintain the project and accepted new contributions.
 The preprint was updated in January 2018, and the article was accepted by the journal in March 2018 [@doi:10.1098/rsif.2017.0387].
+As of June 15, 2018, the Deep Review repository accumulated {{total_commits}} git commits, {{merged_pull_requests}} merged pull requests, and {{open_issues + closed_issues}} issues.
 ](images/deep-review-contribution-ridge.svg){#fig:contrib width="100%"}
 
 ## Manubot

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -78,7 +78,7 @@ This figure reveals the composition of written contributions to the manuscript a
 Deep Review was initiated in August 2016, and the first complete manuscript was released as a preprint [@doi:10.1101/142760] in May 2017.
 While the article was under review, we continued to maintain the project and accepted new contributions.
 The preprint was updated in January 2018, and the article was accepted by the journal in March 2018 [@doi:10.1098/rsif.2017.0387].
-As of June 15, 2018, the Deep Review repository accumulated {{total_commits}} git commits, {{merged_pull_requests}} merged pull requests, and {{open_issues + closed_issues}} issues.
+As of June 15, 2018, the Deep Review repository accumulated {{total_commits}} git commits, {{merged_pull_requests}} merged pull requests, {{open_issues + closed_issues}} issues, and {{github_stars}} GitHub stars.
 ](images/deep-review-contribution-ridge.svg){#fig:contrib width="100%"}
 
 ## Manubot


### PR DESCRIPTION
Closes #42 

I couldn't figure out how to format the `creation_time_utc` stat to automatically populate the date, so it is currently hard coded.  It looks like Jinja2 requires a filter for this:
- https://support.sendwithus.com/jinja/jinja_time/
- http://jinja.pocoo.org/docs/2.10/api/#custom-filters

@dhimmel are there any other [stats](https://github.com/greenelab/meta-review/blob/master/analyses/deep-review-contrib/deep-review-stats.json) we want to add?  These seemed the most relevant to me to show the scale of the project.