### PR TITLE
Update abstract and other miscellaneous edits before resubmission

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -1,7 +1,7 @@
 ## Abstract {.page_break_before}
 
-Scientific literature reviews are ideal for open, collaborative writing.
-Allowing any interested individual to contribute as an author can strengthen a review, providing broad and fair coverage of the subject matter.
-However, the traditional multi-author writing process breaks down at scale.
-We present techniques for overcoming the challenges of open manuscript writing.
-These include approaches for managing distributed authors and our new software, named Manubot, for automating citation and manuscript building.
+Open, collaborative research is a powerful paradigm that can immensely strengthen the scientific process by integrating broad and diverse expertise.
+However, traditional research and multi-author writing processes break down at scale.
+New tools and workflows that rely on automation can ensure correctness and fairness in massively collaborative research.
+We present techniques for overcoming challenges of open research, with special emphasis on manuscript writing.
+These include approaches for managing distributed authors and our new software, named Manubot, for automating citation and many other aspects of manuscript building.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -239,7 +239,8 @@ As an open source project, Manubot can be extended to adopt best practices from 
 
 Several open science efforts are GitHub-based like our collaborative writing process.
 The ReScience [@doi:10.7717/peerj-cs.142], the Journal of Open Source Software [@doi:10.7717/peerj-cs.147], and some other [Open Journals](http://www.theoj.org/) rely on GitHub for peer review and hosting.
-GitHub is also increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and collaborative scholarly reviews combine literature curation with discussion and interpretation.
+Distill uses GitHub for transparent peer review and post-publication peer review [@doi:10.23915/distill.00013].
+GitHub is increasingly used for resource curation [@doi:10.7717/peerj-cs.134], and collaborative scholarly reviews combine literature curation with discussion and interpretation.
 
 ### Limitations
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -4,30 +4,20 @@ The internet enables science to be shared in real-time at a low cost to a global
 This development has decreased the barriers to making science open, while supporting new massively collaborative models of research.
 However, the scientific community requires tools whose workflows encourage openness.
 Manuscripts are the cornerstone of scholarly communication, but drafting and publishing manuscripts has traditionally relied on proprietary or offline tools that do not support _open scholarly writing_, in which anyone is able to contribute and the contribution history is preserved and public.
-We report a new tool and workflow for authoring scholarly manuscripts in the open, as well as the collaborative project that led to its creation.
+We introduce [Manubot](https://github.com/greenelab/manubot-rootstock), a new tool and infrastructure for authoring scholarly manuscripts in the open, and report how it was instrumental for the collaborative project that led to its creation.
 
-Open scholarly writing, a form of crowdsourcing [@pmcid:PMC4719068], has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].
-Literature reviews are typically written in private by an invited team of colleagues.
-In contrast, broadly opening the process to anyone engaged in the topic --- such that planning, organizing, writing, and editing occur collaboratively in a public forum where anyone is welcome to participate --- can maximize a review's value.
-Open drafting of reviews is especially helpful for capturing state-of-the-art knowledge about rapidly advancing research topics at the intersection of existing disciplines where contributors bring diverse opinions and expertise.
-
-Based on our experience leading a recent open review [@tag:techblog_manubot], we discuss the pros and cons of open collaborative writing.
-Our review manuscript [@doi:10.1098/rsif.2017.0387], code-named the Deep Review, surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
-In addition, we introduce [Manubot](https://github.com/greenelab/manubot-rootstock), the infrastructure we created to enable open manuscript writing online for the Deep Review, which was subsequently adopted by other projects.
-
+Based on our experience leading a recent open review [@tag:techblog_manubot], we discuss the advantages and challenges of open collaborative writing, a form of crowdsourcing [@pmcid:PMC4719068].
+Our review manuscript [@doi:10.1098/rsif.2017.0387] was code-named the Deep Review and surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
 We initiated the Deep Review by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
 GitHub is a platform designed for collaborative software development that is adaptable for collaborative writing.
-From the start, we made the GitHub repository public, applying a [Creative Commons Attribution License](https://github.com/greenelab/deep-review/blob/master/LICENSE.md) to the manuscript.
-Next, we encouraged anyone interested to contribute by proposing changes or additions.
+From the start, we made the GitHub repository public with a [Creative Commons Attribution License](https://github.com/greenelab/deep-review/blob/master/LICENSE.md).
+We encouraged anyone interested to contribute by proposing changes or additions.
 Although we invited some specific experts to participate, most authors discovered the manuscript organically through conferences or social media, deciding to contribute without solicitation.
 In total, the Deep Review attracted {{deep_review_authors}} authors, who were not determined in advance, from 20 different institutions.
 
-Writing review articles in a public forum allows review authors to engage with the original researchers to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
-Additionally, discussing manuscripts in the open generates valuable pre-publication peer review of preprints [@tag:Avasthi2018_preprints] or post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063].
-Because incentives to provide public peer review of existing literature [@doi:10.1629/uksg.245] are lacking, open collaborative reviews --- where authorship is open to anyone who makes a valid contribution --- could help spur more post-publication peer review.
-However, inviting wide authorship brings many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
-
-To address these challenges, we developed a manuscript writing process using the Markdown language, the GitHub platform, and our new Manubot tool for automating manuscript generation.
+The Deep Review and other studies that subsequently adopted the Manubot platform were unequivocal successes bolstered by the collaborative approach.
+However, inviting wide authorship brought many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
+The manuscript writing process we developed using the Markdown language, the GitHub platform, and our new Manubot tool for automating manuscript generation addresses these challenges.
 
 ## Contribution workflow
 
@@ -212,6 +202,17 @@ Given the same author contributions, it always produced the same ordered author 
 We annotated the author list to indicate that author order was partly randomized and emphasize that the order did not indicate one author contributed more than another from the same category.
 
 ## Discussion
+
+### Collaborative review manuscripts
+
+Open scholarly writing has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].
+Literature reviews are typically written in private by an invited team of colleagues.
+In contrast, broadly opening the process to anyone engaged in the topic --- such that planning, organizing, writing, and editing occur collaboratively in a public forum where anyone is welcome to participate --- can maximize a review's value.
+Open drafting of reviews is especially helpful for capturing state-of-the-art knowledge about rapidly advancing research topics at the intersection of existing disciplines where contributors bring diverse opinions and expertise.
+
+Writing review articles in a public forum allows review authors to engage with the original researchers to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
+Additionally, discussing manuscripts in the open generates valuable pre-publication peer review of preprints [@tag:Avasthi2018_preprints] or post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063].
+Because incentives to provide public peer review of existing literature [@doi:10.1629/uksg.245] are lacking, open collaborative reviews --- where authorship is open to anyone who makes a valid contribution --- could help spur more post-publication peer review.
 
 ### Additional collaborative writing projects
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -10,7 +10,7 @@ Based on our experience leading a recent open review [@tag:techblog_manubot], we
 Our review manuscript [@doi:10.1098/rsif.2017.0387] was code-named the Deep Review and surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
 We initiated the Deep Review by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
 GitHub is a platform designed for collaborative software development that is adaptable for collaborative writing.
-From the start, we made the GitHub repository public with a [Creative Commons Attribution License](https://github.com/greenelab/deep-review/blob/master/LICENSE.md).
+From the start, we made the GitHub repository public under a [Creative Commons Attribution License](https://github.com/greenelab/deep-review/blob/master/LICENSE.md).
 We encouraged anyone interested to contribute by proposing changes or additions.
 Although we invited some specific experts to participate, most authors discovered the manuscript organically through conferences or social media, deciding to contribute without solicitation.
 In total, the Deep Review attracted {{deep_review_authors}} authors, who were not determined in advance, from 20 different institutions.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -3,7 +3,7 @@
 The internet enables science to be shared in real-time at a low cost to a global audience.
 This development has decreased the barriers to making science open, while supporting new massively collaborative models of research.
 However, the scientific community requires tools whose workflows encourage openness.
-Manuscripts are the cornerstone of scholarly communication, but drafting and publishing manuscripts has traditionally relied on proprietary or offline tools that do not support _open scholarly writing_, by which anyone is able to contribute and the contribution history is preserved and public.
+Manuscripts are the cornerstone of scholarly communication, but drafting and publishing manuscripts has traditionally relied on proprietary or offline tools that do not support _open scholarly writing_, in which anyone is able to contribute and the contribution history is preserved and public.
 We report a new tool and workflow for authoring scholarly manuscripts in the open, as well as the collaborative project that led to its creation.
 
 Open scholarly writing, a form of crowdsourcing [@pmcid:PMC4719068], has particular benefits for review articles, which present the state of the art in a scientific field [@doi:10.1371/journal.pcbi.1003149].

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -57,4 +57,3 @@ author_info:
     affiliations:
       - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison
       - Morgridge Institute for Research
-    funders: NIH U54AI117924


### PR DESCRIPTION
Closes #96.  This pull request also addresses some items in #97.

I won't touch the paragraphs being edited in #99 until after it is merged, if I need to at all.

We wanted to present deep review early in the introduction, but the intro focuses too much on review manuscripts and not enough on why others should use manubot.  I plan to move parts of the intro to a new discussion sub-section on why collaborative writing is beneficial for review manuscripts.

I also removed my funding.  That grant was relevant for deep review but not Manubot or meta review.