### PR TITLE
Consistent citation tag styling

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -6,7 +6,7 @@ However, the scientific community requires tools whose workflows encourage openn
 Manuscripts are the cornerstone of scholarly communication, but drafting and publishing manuscripts has traditionally relied on proprietary or offline tools that do not support _open scholarly writing_, in which anyone is able to contribute and the contribution history is preserved and public.
 We introduce [Manubot](https://github.com/greenelab/manubot-rootstock), a new tool and infrastructure for authoring scholarly manuscripts in the open, and report how it was instrumental for the collaborative project that led to its creation.
 
-Based on our experience leading a recent open review [@tag:techblog_manubot], we discuss the advantages and challenges of open collaborative writing, a form of crowdsourcing [@pmcid:PMC4719068].
+Based on our experience leading a recent open review [@tag:techblog-manubot], we discuss the advantages and challenges of open collaborative writing, a form of crowdsourcing [@pmcid:PMC4719068].
 Our review manuscript [@doi:10.1098/rsif.2017.0387] was code-named the Deep Review and surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
 We initiated the Deep Review by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
 GitHub is a platform designed for collaborative software development that is adaptable for collaborative writing.
@@ -120,7 +120,7 @@ In cases where automatic retrieval of metadata fails or produces incorrect refer
 | PubMed Central Identifier (PMCID) | NCBI's [Citation Exporter](https://www.ncbi.nlm.nih.gov/pmc/tools/ctxp/) | `pmcid:PMC4719068` | [@pmcid:PMC4719068] |
 | arXiv identifier | [arXiv API](https://arxiv.org/help/api/index) | `arxiv:1502.04015v1` | [@arxiv:1502.04015v1] |
 | URL | [Greycite](http://greycite.knowledgeblog.org/) [@arxiv:1304.7151v1] | `url:https://lgatto.github.io/open-and-open/` | [@url:https://lgatto.github.io/open-and-open/] |
-| Tag | Source for tagged identifier | `tag:Avasthi2018_preprints` | [@tag:Avasthi2018_preprints] |
+| Tag | Source for tagged identifier | `tag:avasthi-preprints` | [@tag:avasthi-preprints] |
 
 Table: Citation types supported by Manubot.
 Authors may optionally map a named tag to one of the other supported identifier types.
@@ -181,7 +181,7 @@ Hence, in Manubot's first year, two of the most popular preprints were written u
 
 Additional research studies in progress are being authored using Manubot, spanning the fields of [genomics](https://vsmalladi.github.io/tfsee-manuscript/), [climate science](https://openclimatedata.github.io/global-emissions/), and [data visualization](https://yt-project.github.io/yt-3.0-paper/).
 Manubot is also being used for documents beyond traditional journal publications, such as [grant proposals](https://greenelab.github.io/manufund-2018/), [progress reports](https://greenelab.github.io/czi-hca-report/), [undergraduate research reports](https://zietzm.github.io/Vagelos2017/) [@doi:10.6084/m9.figshare.5346577], [literature reviews](https://slochower.github.io/synthetic-motor-literature/), and lab notebooks.
-Finally, manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steemit-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
+Finally, manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steem-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
 
 ## Authorship
 
@@ -211,7 +211,7 @@ In contrast, broadly opening the process to anyone engaged in the topic --- such
 Open drafting of reviews is especially helpful for capturing state-of-the-art knowledge about rapidly advancing research topics at the intersection of existing disciplines where contributors bring diverse opinions and expertise.
 
 Writing review articles in a public forum allows review authors to engage with the original researchers to clarify their methods and results and present them accurately, as exemplified [here](https://github.com/greenelab/deep-review/issues/213).
-Additionally, discussing manuscripts in the open generates valuable pre-publication peer review of preprints [@tag:Avasthi2018_preprints] or post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063].
+Additionally, discussing manuscripts in the open generates valuable pre-publication peer review of preprints [@tag:avasthi-preprints] or post-publication peer review [@pmid:25851694; @doi:10.1371/journal.pmed.1001772; @doi:10.3389/fncom.2012.00063].
 Because incentives to provide public peer review of existing literature [@doi:10.1629/uksg.245] are lacking, open collaborative reviews --- where authorship is open to anyone who makes a valid contribution --- could help spur more post-publication peer review.
 
 ### Additional collaborative writing projects
@@ -232,7 +232,7 @@ After releasing the first version of the Deep Review [@doi:10.1101/142760], {{de
 Existing authors continue to discuss new literature, [creating a living document](https://github.com/greenelab/deep-review/).
 Manubot provides an ideal platform for perpetual reviews [@arxiv:1502.01329; @tag:livecoms].
 
-Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog_brown].
+Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog-brown].
 Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing.
 Examples of continuous integration to automate manuscript generation include [gh-publisher](https://github.com/ewanmellor/gh-publisher) and Continuous Publishing [@url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/], which was used to produce the book Opening Science [@doi:10.1007/978-3-319-00026-8].
 Distill journal articles [@doi:10.23915/distill.00010], Idyll [@tag:idyll], and Stencila [@tag:stencila] support manuscripts with interactive graphics and close integration with the underlying code.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -1,8 +1,8 @@
 tag	citation
-techblog_manubot	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manubot-powers-a-crowdsourced-deep-learning-review/
-techblog_brown	url:http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future
-Avasthi2018_preprints	doi:10.7554/eLife.38532
-steemit-post	url:https://goo.gl/jAcwjm
+techblog-manubot	url:http://blogs.nature.com/naturejobs/2018/02/20/techblog-manubot-powers-a-crowdsourced-deep-learning-review/
+techblog-brown	url:http://blogs.nature.com/naturejobs/2017/06/01/techblog-c-titus-brown-predicting-the-paper-of-the-future
+avasthi-preprints	doi:10.7554/eLife.38532
+steem-post	url:https://goo.gl/jGBrxE
 idyll	url:https://idyll.pub/post/announcing-idyll-pub-0a3eff0661df3446a915700d/
 stencila	url:https://elifesciences.org/labs/c496b8bb/stencila-an-office-suite-for-reproducible-research
 livecoms	url:http://www.livecomsjournal.org/article/2031-why-we-need-the-living-journal-of-computational-molecular-science

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -146,8 +146,8 @@
   },
   {
     "type": "webpage",
-    "standard_citation": "url:https://goo.gl/jAcwjm",
-    "URL": "https://steemit.com/manubot/@dhimmel/how-i-used-the-manubot-to-reproduce-the-bitcoin-whitepaper",
+    "standard_citation": "url:https://goo.gl/jGBrxE",
+    "URL": "https://busy.org/@dhimmel/how-i-used-the-manubot-to-reproduce-the-bitcoin-whitepaper",
     "title": "How I used the Manubot to reproduce the Bitcoin Whitepaper",
     "container-title": "Steem",
     "issued": {


### PR DESCRIPTION
Use hyphen rather than underscores in tags, such that they are Pandoc compliant without processing.

Switch steemit.com citaiton to busy.org, since I find the later to be a better Steem explorer.