### PR TITLE
Add back-matter paragraph to replace front-matter funding info

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -42,7 +42,7 @@ on {{date}}.
   {%- if author.affiliations is defined %}
      {{author.affiliations | join('; ')}}
   {%- endif %}
-  {%- if author.funders is defined %}
+  {%- if false and author.funders is defined %}
      · Funded by {{author.funders}}
   {%- endif %}
   </small>

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -7,7 +7,8 @@ We are grateful for additional Manubot discussion and testing by Alexander Dunke
 
 ## Funding
 
-This work was supported by the Alfred P. Sloan Foundation in [Grant G-2018-11163](https://sloan.org/grant-detail/8501) to DSH and the Gordon & Betty Moore Foundation in [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) to CSG.
+DSH and CSG were supported by [Grant G-2018-11163](https://sloan.org/grant-detail/8501) from the Alfred P. Sloan Foundation and [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) from the Gordon & Betty Moore Foundation.
+VSM was supported by [Grant RP150596](http://www.cprit.state.tx.us/files/funded-grants/RP150596.pdf) from the Cancer Prevention and Research Institute of Texas.
 
 ## References {.page_break_before}
 

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -7,7 +7,7 @@ We are grateful for additional Manubot discussion and testing by Alexander Dunke
 
 ## Funding
 
-DSH and CSG were supported by [Grant G-2018-11163](https://sloan.org/grant-detail/8501) from the Alfred P. Sloan Foundation and [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) from the Gordon & Betty Moore Foundation.
+DSH and CSG were supported by [Grant G-2018-11163](https://sloan.org/grant-detail/8501) from the Alfred P. Sloan Foundation and [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) from the Gordon and Betty Moore Foundation.
 VSM was supported by [Grant RP150596](http://www.cprit.state.tx.us/files/funded-grants/RP150596.pdf) from the Cancer Prevention and Research Institute of Texas.
 
 ## References {.page_break_before}

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -1,9 +1,13 @@
-## Acknowledgements
+## Acknowledgments
 
 We would like to thank the authors of the Deep Review who helped us test collaborative writing with Manubot.
 The authors who responded favorably to being acknowledged are Paul-Michael Agapow, Amr M. Alexandari, Brett K. Beaulieu-Jones, Anne E. Carpenter, Travers Ching, Evan M. Cofer, Dave DeCaprio, Brian T. Do, Enrico Ferrero, David J. Harris, Michael M. Hoffman, Alexandr A. Kalinin, Anshul Kundaje, Jack Lanchantin, Christopher A. Lavender, Benjamin J. Lengerich, Zhiyong Lu, Yifan Peng, Yanjun Qi, Gail L. Rosen, Avanti Shrikumar, Srinivas C. Turaga, Gregory P. Way, Laura K. Wiley, Stephen Woloszynek, Wei Xie, Jinbo Xu, and Michael Zietz.
 In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contributing to the Manubot template manuscript.
 We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Achintya Rao, and other GitHub users.
+
+## Funding
+
+This work was supported by the Alfred P. Sloan Foundation in [Grant G-2018-11163](https://sloan.org/grant-detail/8501) to DSH and the Gordon & Betty Moore Foundation in [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) to CSG.
 
 ## References {.page_break_before}
 

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -16,7 +16,7 @@ author_info:
     email: daniel.himmelstein@gmail.com
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
-    funders: GBMF4552
+    funders: G-2018-11163 and GBMF4552
   -
     github: slochower
     name: David R. Slochower
@@ -46,7 +46,7 @@ author_info:
     email: csgreene@upenn.edu
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
-    funders: GBMF4552
+    funders: G-2018-11163 and GBMF4552
   -
     github: agitter
     name: Anthony Gitter


### PR DESCRIPTION
At some point, we should probably create an in-body paragraph regarding funding, as I'm guessing it'll be eventually required by a journal. At that point, we can remove the frontmatter funding snippets (or keep them if we don't mind the redundancy).