### PR TITLE
Add Kipoi use case

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -182,7 +182,7 @@ Hence, in Manubot's first year, two of the most popular preprints were written u
 Additional research studies in progress are being authored using Manubot, spanning the fields of [genomics](https://vsmalladi.github.io/tfsee-manuscript/), [climate science](https://openclimatedata.github.io/global-emissions/), and [data visualization](https://yt-project.github.io/yt-3.0-paper/).
 Manubot is also being used for documents beyond traditional journal publications, such as [grant proposals](https://greenelab.github.io/manufund-2018/), [progress reports](https://greenelab.github.io/czi-hca-report/), [undergraduate research reports](https://zietzm.github.io/Vagelos2017/) [@doi:10.6084/m9.figshare.5346577], [literature reviews](https://slochower.github.io/synthetic-motor-literature/), and lab notebooks.
 Manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steem-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
-Finally, the Kipoi model zoo for genomics [@doi:10.1101/375345] uses Manubot's citation utility to automatically extract model authors.
+Finally, the Kipoi model zoo for genomics [@doi:10.1101/375345] uses Manubot's citation functionality to automatically extract model authors.
 
 ## Authorship
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -181,7 +181,8 @@ Hence, in Manubot's first year, two of the most popular preprints were written u
 
 Additional research studies in progress are being authored using Manubot, spanning the fields of [genomics](https://vsmalladi.github.io/tfsee-manuscript/), [climate science](https://openclimatedata.github.io/global-emissions/), and [data visualization](https://yt-project.github.io/yt-3.0-paper/).
 Manubot is also being used for documents beyond traditional journal publications, such as [grant proposals](https://greenelab.github.io/manufund-2018/), [progress reports](https://greenelab.github.io/czi-hca-report/), [undergraduate research reports](https://zietzm.github.io/Vagelos2017/) [@doi:10.6084/m9.figshare.5346577], [literature reviews](https://slochower.github.io/synthetic-motor-literature/), and lab notebooks.
-Finally, manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steem-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
+Manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steem-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
+Finally, the Kipoi model zoo for genomics [@doi:10.1101/375345] uses Manubot's citation utility to automatically extract model authors.
 
 ## Authorship
 


### PR DESCRIPTION
Addresses another item from #97.

I wasn't sure how to phrase this:
- `Manubot's citation utility` (current option)
- `Manubot's citation API`
- `Manubot's citation features`