### PR TITLE
Authorship on Manubot manuscripts

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -232,7 +232,7 @@ Although these criteria provided a straightforward, equitable way to determine w
 In biomedical journals, the convention is that the first and last authors made the most substantial contributions to the manuscript.
 This convention can be difficult to reconcile in a collaborative effort.
 Using git, we could quantify the number of commits each author made or the number of sentences an author wrote or edited, but these metrics discount intellectual contributions such as discussing primary literature and reviewing pull requests.
-However, there is no objective system to compare and weight the different types of contributions and produce an ordered author list.
+Therefore, we concluded that it is not possible to construct an objective system to compare and weight the different types of contributions and produce an ordered author list.
 
 To address this issue, we generalized the concept of "co-first" authorship, in which two or more authors are denoted as making equal contributions to a paper.
 We defined four types of contributions [@doi:10.1098/rsif.2017.0387], from major to minor, and reviewed the GitHub discussions and commits to assign authors to these categories.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -85,7 +85,7 @@ The contributor made the pull request, and two maintainers and another participa
 After four rounds of reviews and pull request edits, a maintainer merged the changes.
 
 We found that this workflow was an effective compromise between fully unrestricted editing and a more heavily-structured approach that limited the authors or the sections they could edit.
-In addition, authors are associated with their commits, which makes it easy for contributors to receive credit for their work and helps prevent ghostwriting [@doi:10.1371/journal.pmed.1000023].
+In addition, authors are associated with their commits, which makes it easy for contributors to receive credit for their work.
 Figure @fig:contrib and the GitHub [contributors page](https://github.com/greenelab/deep-review/graphs/contributors) summarize all edits and commits from each author, providing aggregated information that is not available on other collaborative writing platforms.
 Because the Manubot writing process tracks the complete history through git commits, it enables detailed retrospective contribution analysis.
 
@@ -220,8 +220,9 @@ manubot cite --render --format=markdown \
 
 Manubot does not impose any restrictions on authorship.
 It allows authors to adhere to the author inclusion and author ordering conventions of their field.
-Some Manubot projects create a table in their GitHub repository to track contributors who did not commit text to the manuscript.
+Some Manubot projects create a [table](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) in their GitHub repository to track contributors who did not commit text to the manuscript.
 This provides a transparent way to record contributions such as experimental research that generated data for the manuscript and discuss whether they meet that project's authorship criteria.
+Contribution transparency helps prevent ghostwriting [@doi:10.1371/journal.pmed.1000023] and is especially important in collaborative writing [@doi:10.1371/journal.pcbi.1006508].
 Although we recommend authors provide their ORCID and GitHub username, Manubot also supports pseudonyms, pseudonymous GitHub usernames, and authors without an ORCID or GitHub account.
 
 To determine authorship for the Deep Review, we followed the International Committee of Medical Journal Editors (ICMJE) [guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) and used GitHub to track contributions.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -23,7 +23,7 @@ The manuscript writing process we developed using the Markdown language, the Git
 
 There are many existing collaborative writing platforms ranging from rich text editors, which support Microsoft Word documents or similar formats, to LaTeX-based systems for technical writing [@doi:10.1038/514127a] such as [Overleaf](https://www.overleaf.com/) and [Authorea](https://www.authorea.com/).
 These platforms ideally offer version control, multiple permission levels, or other functionality to support multi-author document editing.
-Although they work well for editing text, they lack sufficient features for managing a collaborative manuscript with many authors and attributing precise credit, which are important for open writing (Table @tbl:platforms). 
+Although they work well for editing text, they lack sufficient features for managing a collaborative manuscript with many authors and attributing precise credit, which are important for open writing (Table @tbl:platforms).
 Furthermore, none of these platforms offer the ability to address thematically related changes together and enable multiple authors to iteratively refine proposed changes.
 
 | Feature | Manubot | Authorea + BibTeX | Overleaf v1 + BibTeX | Google Docs + Paperpile | Word Online<sup>1</sup> | Markdown on GitHub |
@@ -199,10 +199,6 @@ As such, continuous publishing via Manubot helped the authors address the error 
 This Sci-Hub Coverage Study preprint was the [most viewed](http://web.archive.org/web/20171221221858/http://www.prepubmed.org/top_preprints/) 2017 _PeerJ Preprint_, while the Deep Review was the most viewed 2017 _bioRxiv_ preprint [@doi:10.1038/d41586-017-08493-x].
 Hence, in Manubot's first year, two of the most popular preprints were written using its collaborative, open, and review-driven authoring process.
 
-Papers with hundreds or thousands of authors are on the rise, such as the article describing the experiments and data that led to the discovery of the Higgs Boson [@doi:10.1103/PhysRevLett.114.191803] (5000 authors) and the report of the Drosophila genome [@doi:10.1534/g3.114.015966] (1000 authors).
-Yet _the number of people that participated in writing_ those papers, as opposed to generating and analyzing the data, is not always clear and likely to be far below the number of authors [@doi:10.1038/521263f; @doi:10.1038/nature.2015.17567].
-Manubot provides the scientists involved in large collaborations the opportunity to activtely participate, through a public forum, in the writing process.
-
 Additional research studies in progress are being authored using Manubot, spanning the fields of [genomics](https://vsmalladi.github.io/tfsee-manuscript/), [climate science](https://openclimatedata.github.io/global-emissions/), and [data visualization](https://yt-project.github.io/yt-3.0-paper/).
 Manubot is also being used for documents beyond traditional journal publications, such as [grant proposals](https://greenelab.github.io/manufund-2018/), [progress reports](https://greenelab.github.io/czi-hca-report/), [undergraduate research reports](https://zietzm.github.io/Vagelos2017/) [@doi:10.6084/m9.figshare.5346577], [literature reviews](https://slochower.github.io/synthetic-motor-literature/), and lab notebooks.
 Manuscripts written with other authoring systems have been successfully ported to Manubot, including the [Bitcoin Whitepaper](https://git.dhimmel.com/bitcoin-whitepaper/) [@tag:steem-post] and [Project Rephetio manuscript](https://git.dhimmel.com/rephetio-manuscript/) [@doi:10.7554/eLife.26726].
@@ -263,6 +259,10 @@ While debate was raging over tightening the default threshold for statistical si
 The greatest success to date of open collaborative writing is arguably Wikipedia, whose English version contains over 5.5 million articles.
 Wikipedia scaled encyclopedias [far beyond](https://en.wikipedia.org/wiki/Wikipedia:Size_comparisons) any privately-written alternative.
 These examples illustrate how open collaborative writing can scale scholarly manuscripts where diverse opinion and expertise are paramount beyond what would otherwise be possible.
+
+Papers with hundreds or thousands of authors are on the rise, such as the article describing the experiments and data that led to the discovery of the Higgs Boson [@doi:10.1103/PhysRevLett.114.191803] (5000 authors) and the report of the Drosophila genome [@doi:10.1534/g3.114.015966] (1000 authors).
+Yet _the number of people that participated in writing_ those papers, as opposed to generating and analyzing the data, is not always clear and likely to be far below the number of authors [@doi:10.1038/521263f; @doi:10.1038/nature.2015.17567].
+Manubot provides the scientists involved in large collaborations the opportunity to actively participate, through a public forum, in the writing process.
 
 Open writing also presents new opportunities for distributing scholarly communication.
 Though it is still valuable to have versioned drafts of a manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -242,6 +242,10 @@ Given the same author contributions, it always produced the same ordered author 
 We annotated the author list to indicate that author order was partly randomized and emphasize that the order did not indicate one author contributed more than another from the same category.
 The Deep Review author ordering procedure illustrates authorship possibilities when all contributions are publicly tracked and recorded that would be difficult with a traditional collaborative writing platform.
 
+Papers with hundreds or thousands of authors are on the rise, such as the article describing the experiments and data that led to the discovery of the Higgs Boson [@doi:10.1103/PhysRevLett.114.191803] (5000 authors) and the report of the Drosophila genome [@doi:10.1534/g3.114.015966] (1000 authors).
+Yet _the number of people that participated in writing_ those papers, as opposed to generating and analyzing the data, is not always clear and likely to be far below the number of authors [@doi:10.1038/521263f; @doi:10.1038/nature.2015.17567].
+Manubot provides the scientists involved in large collaborations the opportunity to actively participate, through a public forum, in the writing process.
+
 ## Discussion
 
 ### Collaborative review manuscripts
@@ -266,10 +270,6 @@ While debate was raging over tightening the default threshold for statistical si
 The greatest success to date of open collaborative writing is arguably Wikipedia, whose English version contains over 5.5 million articles.
 Wikipedia scaled encyclopedias [far beyond](https://en.wikipedia.org/wiki/Wikipedia:Size_comparisons) any privately-written alternative.
 These examples illustrate how open collaborative writing can scale scholarly manuscripts where diverse opinion and expertise are paramount beyond what would otherwise be possible.
-
-Papers with hundreds or thousands of authors are on the rise, such as the article describing the experiments and data that led to the discovery of the Higgs Boson [@doi:10.1103/PhysRevLett.114.191803] (5000 authors) and the report of the Drosophila genome [@doi:10.1534/g3.114.015966] (1000 authors).
-Yet _the number of people that participated in writing_ those papers, as opposed to generating and analyzing the data, is not always clear and likely to be far below the number of authors [@doi:10.1038/521263f; @doi:10.1038/nature.2015.17567].
-Manubot provides the scientists involved in large collaborations the opportunity to actively participate, through a public forum, in the writing process.
 
 Open writing also presents new opportunities for distributing scholarly communication.
 Though it is still valuable to have versioned drafts of a manuscript with digital identifiers, journal publication may not be the terminal endpoint for collaborative manuscripts.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -219,7 +219,7 @@ manubot cite --render --format=markdown \
 ## Authorship
 
 Manubot does not impose any restrictions on authorship.
-It allows authors to adhere to the author inclusion and author ordering conventions of their field.
+It allows authors to adhere to the author inclusion and author ordering conventions of their field, which vary considerably across disciplines [@doi:10.1371/journal.pone.0023477].
 Some Manubot projects create a [table](https://github.com/Benjamin-Lee/deep-rules/blob/master/contributors.md) in their GitHub repository to track contributors who did not commit text to the manuscript.
 This provides a transparent way to record contributions such as experimental research that generated data for the manuscript and discuss whether they meet that project's authorship criteria.
 Contribution transparency helps prevent ghostwriting [@doi:10.1371/journal.pmed.1000023] and is especially important in collaborative writing [@doi:10.1371/journal.pcbi.1006508].

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -218,6 +218,12 @@ manubot cite --render --format=markdown \
 
 ## Authorship
 
+Manubot does not impose any restrictions on authorship.
+It allows authors to adhere to the author inclusion and author ordering conventions of their field.
+Some Manubot projects create a table in their GitHub repository to track contributors who did not commit text to the manuscript.
+This provides a transparent way to record contributions such as experimental research that generated data for the manuscript and discuss whether they meet that project's authorship criteria.
+Although we recommend authors provide their ORCID and GitHub username, Manubot also supports pseudonyms, pseudonymous GitHub usernames, and authors without an ORCID or GitHub account.
+
 To determine authorship for the Deep Review, we followed the International Committee of Medical Journal Editors (ICMJE) [guidelines](http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html) and used GitHub to track contributions.
 ICMJE recommends authors substantially contribute to, draft, approve, and agree to be accountable for the manuscript.
 We acknowledged other contributors who did not meet all four criteria, including contributors who provided text but did not review and approve the complete manuscript.
@@ -233,7 +239,7 @@ A randomized algorithm then arbitrarily ordered authors within each contribution
 The randomization procedure was shared with the authors in advance (pre-registered) and run in a deterministic manner.
 Given the same author contributions, it always produced the same ordered author list.
 We annotated the author list to indicate that author order was partly randomized and emphasize that the order did not indicate one author contributed more than another from the same category.
-The Deep Review author ordering procedure is not inherent to writing with Manubot but illustrates the authorship possibilities when all contributions are publicly tracked and recorded.
+The Deep Review author ordering procedure illustrates authorship possibilities when all contributions are publicly tracked and recorded that would be difficult with a traditional collaborative writing platform.
 
 ## Discussion
 

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -31,7 +31,7 @@ We discussed this point in [GH131](https://github.com/greenelab/meta-review/issu
 While we found a number of "mega papers" in the fields of physics and biology, we were unable to quantify how many authors of those papers were able to participate in the process of discussing, drafting, and composing the final articles (versus e.g., conceptualizing the process, collecting or analyzing the data, and so on).
 In fact, more than one press release related to those articles note the difficulty "[merging author lists](https://www.nature.com/news/physics-paper-sets-record-with-more-than-5-000-authors-1.17567)" and disagreements about authorship.
 Manubot allows each author—and other interested parties—the ability to contribute in a way that other platforms do not.
-To that end, we've added three sentences in the Discussion section addressing this point.
+To that end, we've added a paragraph in the Authorship section addressing this point.
 
 > `For now, the primary Manubot output is HTML intended to be viewed in a web browser.`
 → I would insist a bit more on this part because it is a real strength if you consider a future integration with interactive figures (e.g. bokeh) and/or Jupyter notebooks.
@@ -68,7 +68,15 @@ In the interest of frequent releases, we want to keep the effort required to mak
 
 > On the Authorship, how do you give credits to people having participated in a work (e.g. did all the experiment) but did not commit anything on the manuscript?
 
+We added a new paragraph to the Authorship section to clarify that Manubot does not force authors to follow the conventions we used for the Deep Review manuscript.
+Authors are free to follow the authorship conventions of their discipline, which can include authors who did not commit anything to the manuscript.
+This feedback was discussed in [GH136](https://github.com/greenelab/meta-review/issues/136) and addressed in [GH177](https://github.com/greenelab/meta-review/pull/177).
+
 > On the Authorship, how do you deal with people being not identified (e.g. only a GitHub pseudo)?
+
+Related to the comment above, the new Authorship section clarifies that pseudonyms and pseudonymous GitHub usernames are allowed in Manubot manuscripts.
+Authorship information is entered as text in a manuscript metadata file so any author name conventions can be followed.
+This feedback was discussed in [GH137](https://github.com/greenelab/meta-review/issues/137) and addressed in [GH177](https://github.com/greenelab/meta-review/pull/177).
 
 > Is it possible to use manubot on a private GitHub repository?
 I'm pretty sure some people would be interested in using manubot but probably would not use it for open editing.
@@ -193,6 +201,9 @@ While retroactively editing versioned HTML manuscripts is technically possible, 
 > Strengthen statement about `no objective system` for authorship.
 The statement "there is no objective system" reads like it could be a practical statement as in "we haven't built one yet", while I believe (and think the authors agree with me, based on the paragraph) that no such principled objective system _can_ exist.
 Either way this should be clarified.
+
+We clarified that our opinion is that no objective system can exist.
+See [GH123](https://github.com/greenelab/meta-review/issues/123) for the discussion and [GH177](https://github.com/greenelab/meta-review/pull/177) for the manuscript edits.
 
 ***
 


### PR DESCRIPTION
Closes #110
Closes #123 
Closes #136 
Closes #137 

This a work in progress to address a few issues related to authorship.  I also moved the authorship-related text from #169 in anticipation of other restructuring in the Manubot section.