### PR TITLE
Address deep review issues

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -19,7 +19,7 @@ The Deep Review and other studies that subsequently adopted the Manubot platform
 However, inviting wide authorship brought many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.
 The manuscript writing process we developed using the Markdown language, the GitHub platform, and our new Manubot tool for automating manuscript generation addresses these challenges.
 
-## Contribution workflow
+## Manubot contribution workflow
 
 There are many existing collaborative writing platforms ranging from rich text editors, which support Microsoft Word documents or similar formats, to LaTeX-based systems for technical writing [@doi:10.1038/514127a] such as [Overleaf](https://www.overleaf.com/) and [Authorea](https://www.authorea.com/).
 These platforms ideally offer version control, multiple permission levels, or other functionality to support multi-author document editing.
@@ -50,12 +50,13 @@ There is no integrated forum for discussing and editing revisions.
 3. In some circumstances, Overleaf git commits are not modular. Edits made by distinct authors may be attributed to a single author.
 {#tbl:platforms}
 
-In our workflow, we adopt standard software development strategies that enable any contributor to edit any part of the manuscript but enforce discussion and review of all proposed changes.
+Manubot's collaborative writing workflow adopts standard software development strategies that enable any contributor to edit any part of the manuscript but enforce discussion and review of all proposed changes.
 The GitHub platform supports organizing and editing the manuscript.
-We use GitHub _issues_ for organization, opening a new issue for each discussion topic.
+Manubot projects use GitHub _issues_ for organization, opening a new issue for each discussion topic.
 For example, in a review manuscript like the Deep Review, this includes each primary paper under consideration.
 Within a paper's issue, contributors summarize the research, discuss it (sometimes with participation from the original authors), and assess its relevance to the review.
-Issues also serve as an open to-do list and a forum for debating the main message, themes, and topics of the review.
+In a primary research article, issues can instead track progress on specific figures or subsections of text being drafted.
+Issues serve as an open to-do list and a forum for debating the main messages of the manuscript.
 
 GitHub and the underlying git version control system [@doi:10.1371/journal.pcbi.1004668; @doi:10.1371/journal.pcbi.1004947] also structure the writing process.
 The official version of the manuscript is _forked_ by individual contributors.
@@ -91,6 +92,7 @@ We found that this workflow was an effective compromise between fully unrestrict
 In addition, authors are associated with their commits, which makes it easy for contributors to receive credit for their work.
 Figure @fig:contrib and the GitHub [contributors page](https://github.com/greenelab/deep-review/graphs/contributors) summarize all edits and commits from each author, providing aggregated information that is not available on other collaborative writing platforms.
 Because the Manubot writing process tracks the complete history through git commits, it enables detailed retrospective contribution analysis.
+These pull request and contribution tracking examples both come from Deep Review, the largest Manubot project to date, but illustrate the general principles of transparency and collaboration that are shared by all open Manubot manuscripts.
 
 ![
 **Deep Review contributions by author over time.**
@@ -104,7 +106,7 @@ As of {{creation_date_pretty}}, the Deep Review repository accumulated {{total_c
 The notebook to generate this figure can be [interactively launched using Binder](https://mybinder.org/v2/gh/greenelab/meta-review/binder?filepath=analyses/deep-review-contrib/02.contrib-viz.ipynb) [@doi:10.25080/Majora-4af1f417-011], enabling users to explore alternative visualizations or analyses of the source data.
 ](images/deep-review-contribution-ridge.svg){#fig:contrib width="100%"}
 
-## Manubot
+## Manubot features
 
 Manubot is a system for writing scholarly manuscripts via GitHub that is built upon our [Python package](https://github.com/manubot/manubot) of the same name.
 With Manubot, manuscripts are written as plain-text Markdown files, which is well suited for version control using git.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -8,12 +8,12 @@ We introduce [Manubot](https://manubot.org), a new tool and infrastructure for a
 
 Based on our experience leading a recent open review [@tag:techblog-manubot], we discuss the advantages and challenges of open collaborative writing, a form of crowdsourcing [@pmcid:PMC4719068].
 Our review manuscript [@doi:10.1098/rsif.2017.0387] was code-named the Deep Review and surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
-We initiated the Deep Review by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
+We initiated the Deep Review in August 2016 by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
 GitHub is a platform designed for collaborative software development that is adaptable for collaborative writing.
 From the start, we made the GitHub repository public under a [Creative Commons Attribution 4.0 International (CC BY 4.0) license](https://github.com/greenelab/deep-review/blob/master/LICENSE.md).
 We encouraged anyone interested to contribute by proposing changes or additions.
 Although we invited some specific experts to participate, most authors discovered the manuscript organically through conferences or social media, deciding to contribute without solicitation.
-In total, the Deep Review attracted {{deep_review_authors}} authors, who were not determined in advance, from 20 different institutions.
+In total, the Deep Review attracted {{deep_review_authors}} authors, who were not determined in advance, from 20 different institutions in less than two years.
 
 The Deep Review and other studies that subsequently adopted the Manubot platform were unequivocal successes bolstered by the collaborative approach.
 However, inviting wide authorship brought many technical and social challenges such as how to fairly distribute credit, coordinate the scientific content, and collaboratively manage extensive reference lists.

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -19,6 +19,11 @@ One minor suggestion/comment - it wasn't clear why the Manubot description came 
 Is it not true that DR was a first instance use of Manubot? If so, why not describe the tool, then describe DR as the pilot?
 Generally it read as though those two sections were distinct, while I think the authors intended that they be part of a bigger story.
 
+We thank the reviewer for pointing out that that original organization was confusing.
+The intention of the section previously titled `Contribution workflow` is to present the overall philosophy of collaborative writing with Manubot before diving into specific Manubot features that enable this writing process.
+Deep Review is used as to provide specific examples of the collaborative process.
+We restructured this section, now named `Manubot contribution workflow`, and generalized it in [GH183](https://github.com/greenelab/meta-review/pull/183) and discussed the changes in [GH129](https://github.com/greenelab/meta-review/pull/129).
+
 ## Reviewer 2
 
 > Overall, the article is nicely written and corresponds to a software paper (in my opinion).
@@ -110,7 +115,15 @@ See [GH142](https://github.com/greenelab/meta-review/issues/142) and [GH170](htt
 > `We initiated the Deep Review` → when?
 Would be nice to give some date at this point.
 
+Deep Review as started in August 2016.
+We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143)
+and made the requested change [GH183](https://github.com/greenelab/meta-review/pull/183).
+
 > `In total, the Deep Review attracted...` → in less than a few weeks? months? years?
+
+This referred to the less than two year period from August 2016 when the Deep Review project started to March 2018 when the journal submission was accepted.
+We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143)
+and made the requested change [GH183](https://github.com/greenelab/meta-review/pull/183).
 
 > `we made the GitHub repository public under a Creative Commons Attribution License.` → The link points to CC-BY 4.0 International, it would be good to have this information in the name of the link (or we have to click to check which kind CC you used).
 

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -115,15 +115,13 @@ See [GH142](https://github.com/greenelab/meta-review/issues/142) and [GH170](htt
 > `We initiated the Deep Review` → when?
 Would be nice to give some date at this point.
 
-Deep Review as started in August 2016.
-We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143)
-and made the requested change [GH183](https://github.com/greenelab/meta-review/pull/183).
+Deep Review was started in August 2016.
+We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143) and added the date to the manuscript in [GH183](https://github.com/greenelab/meta-review/pull/183).
 
 > `In total, the Deep Review attracted...` → in less than a few weeks? months? years?
 
 This referred to the less than two year period from August 2016 when the Deep Review project started to March 2018 when the journal submission was accepted.
-We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143)
-and made the requested change [GH183](https://github.com/greenelab/meta-review/pull/183).
+We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pull/143) and made the requested change in [GH183](https://github.com/greenelab/meta-review/pull/183).
 
 > `we made the GitHub repository public under a Creative Commons Attribution License.` → The link points to CC-BY 4.0 International, it would be good to have this information in the name of the link (or we have to click to check which kind CC you used).
 


### PR DESCRIPTION
Closes #129
Closes #143
Closes #144

My prior edit 9698331ebb8335dc3f6f73d196b7c9abb38111dd is also relevant here.  I tried to make it clear that the contribution workflow is about Manubot in general, Deep Review is only an example.

I'd still like to add a closing paragraph to the introduction about Manubot's features to further help with #129.

@vsmalladi I recommend adding a short paragraph about using Manubot on private repositories after the sentence `These pull request and contribution tracking examples both come from Deep Review, the largest Manubot project to date, but illustrate the general principles of transparency and collaboration that are shared by all open Manubot manuscripts.` when you work on #138.  You can transition with something like `Manubot can also be used on private manuscripts...`.