### PR TITLE
Update acknowledgements

### DIFF
--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -8,7 +8,7 @@ We thank John MacFarlane and Nikolay Yakimov for assistance with Pandoc and the 
 
 ## Funding
 
-DSH and CSG were supported by [Grant G-2018-11163](https://sloan.org/grant-detail/8501) from the Alfred P. Sloan Foundation and [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) from the Gordon and Betty Moore Foundation.
+DSH, DH, VR, and CSG were supported by [Grant G-2018-11163](https://sloan.org/grant-detail/8501) from the Alfred P. Sloan Foundation and [Grant GBMF4552](https://www.moore.org/grant-detail?grantId=GBMF4552) from the Gordon and Betty Moore Foundation.
 VSM was supported by [Grant RP150596](http://www.cprit.state.tx.us/files/funded-grants/RP150596.pdf) from the Cancer Prevention and Research Institute of Texas.
 
 ## References {.page_break_before}

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -6,6 +6,8 @@ In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contri
 We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Benjamin J. Heil, Zach Hensel, Alexandra J. Lee, YoSon Park, Achintya Rao, and other GitHub users.
 We thank John MacFarlane and Nikolay Yakimov for assistance with Pandoc and the global Binder team for advice on Binder.
 Finally, we thank C. Titus Brown and the other anonymous reviewers for their help improving this manuscript.
+Their feedback and our responses are available on [GitHub](https://github.com/greenelab/meta-review/blob/998ed62f1e2e21c58bff2a88ac7387b6b8781fab/content/response-to-reviewers.md).  
+** TODO: update `response-to-reviewers.md` URL once it is finalized **
 
 ## Funding
 

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -3,8 +3,8 @@
 We would like to thank the authors of the Deep Review who helped us test collaborative writing with Manubot.
 The authors who responded favorably to being acknowledged are Paul-Michael Agapow, Amr M. Alexandari, Brett K. Beaulieu-Jones, Anne E. Carpenter, Travers Ching, Evan M. Cofer, Dave DeCaprio, Brian T. Do, Enrico Ferrero, David J. Harris, Michael M. Hoffman, Alexandr A. Kalinin, Anshul Kundaje, Jack Lanchantin, Christopher A. Lavender, Benjamin J. Lengerich, Zhiyong Lu, Yifan Peng, Yanjun Qi, Gail L. Rosen, Avanti Shrikumar, Srinivas C. Turaga, Gregory P. Way, Laura K. Wiley, Stephen Woloszynek, Wei Xie, Jinbo Xu, and Michael Zietz.
 In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contributing to the Manubot template manuscript.
-We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Achintya Rao, and other GitHub users.
-We thank John MacFarlane for assistance with pandoc and the global Binder team for advice on Binder.
+We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Benjamin J. Heil, Zach Hensel, Alexandra J. Lee, YoSon Park, Achintya Rao, and other GitHub users.
+We thank John MacFarlane and Nikolay Yakimov for assistance with Pandoc and the global Binder team for advice on Binder.
 
 ## Funding
 

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -6,8 +6,6 @@ In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contri
 We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Benjamin J. Heil, Zach Hensel, Alexandra J. Lee, YoSon Park, Achintya Rao, and other GitHub users.
 We thank John MacFarlane and Nikolay Yakimov for assistance with Pandoc and the global Binder team for advice on Binder.
 Finally, we thank C. Titus Brown and the other anonymous reviewers for their help improving this manuscript.
-Their feedback and our responses are available on [GitHub](https://github.com/greenelab/meta-review/blob/998ed62f1e2e21c58bff2a88ac7387b6b8781fab/content/response-to-reviewers.md).  
-** TODO: update `response-to-reviewers.md` URL once it is finalized **
 
 ## Funding
 

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -4,7 +4,6 @@ We would like to thank the authors of the Deep Review who helped us test collabo
 The authors who responded favorably to being acknowledged are Paul-Michael Agapow, Amr M. Alexandari, Brett K. Beaulieu-Jones, Anne E. Carpenter, Travers Ching, Evan M. Cofer, Dave DeCaprio, Brian T. Do, Enrico Ferrero, David J. Harris, Michael M. Hoffman, Alexandr A. Kalinin, Anshul Kundaje, Jack Lanchantin, Christopher A. Lavender, Benjamin J. Lengerich, Zhiyong Lu, Yifan Peng, Yanjun Qi, Gail L. Rosen, Avanti Shrikumar, Srinivas C. Turaga, Gregory P. Way, Laura K. Wiley, Stephen Woloszynek, Wei Xie, Jinbo Xu, and Michael Zietz.
 In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contributing to the Manubot template manuscript.
 We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Achintya Rao, and other GitHub users.
-Setup and maintenance of the Zotero translation-server for Manubot usage was performed by Dongbo Hu.
 We thank John MacFarlane for assistance with pandoc and the global Binder team for advice on Binder.
 
 ## Funding

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -5,6 +5,7 @@ The authors who responded favorably to being acknowledged are Paul-Michael Agapo
 In addition, we thank Ogun Adebali, Evan M. Cofer, and Robert Gieseke for contributing to the Manubot template manuscript.
 We are grateful for additional Manubot discussion and testing by Alexander Dunkel, Ansel Halliburton, Benjamin J. Heil, Zach Hensel, Alexandra J. Lee, YoSon Park, Achintya Rao, and other GitHub users.
 We thank John MacFarlane and Nikolay Yakimov for assistance with Pandoc and the global Binder team for advice on Binder.
+Finally, we thank C. Titus Brown and the other anonymous reviewers for their help improving this manuscript.
 
 ## Funding
 


### PR DESCRIPTION
Closes #126.

This updates the acknowledgements to include everyone who approved their inclusion as of https://github.com/greenelab/meta-review/issues/126#issuecomment-477205076

It also adds the new authors the funding statement.