### PR TITLE
Add description of private manuscripts

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -227,7 +227,8 @@ Furthermore, versioned URLs, such as <https://greenelab.github.io/meta-review/v/
 
 The Manubot examples in this manuscript use open public GitHub repositories.
 However, it is also possible to take advantage of Manubot's continuous publishing for a private manuscript by using a private GitHub repository and disabling GitHub Pages.
-In this private setting, the manuscript HTML and PDF outputs are automatically generated when the manuscript source is updated, but only GitHub users granted access to the repository are able to download them.
+This requires additional custom configuration.
+In the private setting, the manuscript HTML and PDF outputs are automatically generated when the manuscript source is updated, but only GitHub users granted access to the repository are able to download them.
 
 ### Timestamping
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -225,6 +225,10 @@ If successful, the output is deployed back to GitHub (to dedicated [`output`](ht
 As a result, <https://greenelab.github.io/meta-review> stays up to date with the latest HTML manuscript.
 Furthermore, versioned URLs, such as <https://greenelab.github.io/meta-review/v/4b6396bcefd1b9c7ddf39c1d3f0b3eab2dd63f31/>, provide access to previous manuscript versions.
 
+The Manubot examples in this manuscript use open public GitHub repositories.
+However, it is also possible to take advantage of Manubot's continuous publishing for a private manuscript by using a private GitHub repository and disabling GitHub Pages.
+In this private setting, the manuscript HTML and PDF outputs are automatically generated when the manuscript source is updated, but only GitHub users granted access to the repository are able to download them.
+
 ### Timestamping
 
 The idea of the "priority of discovery" is important to science, and Vale and Hyman discuss the importance of both disclosure and validation [@doi:10.7554/eLife.16931].

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -225,11 +225,6 @@ If successful, the output is deployed back to GitHub (to dedicated [`output`](ht
 As a result, <https://greenelab.github.io/meta-review> stays up to date with the latest HTML manuscript.
 Furthermore, versioned URLs, such as <https://greenelab.github.io/meta-review/v/4b6396bcefd1b9c7ddf39c1d3f0b3eab2dd63f31/>, provide access to previous manuscript versions.
 
-The Manubot examples in this manuscript use open public GitHub repositories.
-However, it is also possible to take advantage of Manubot's continuous publishing for a private manuscript by using a private GitHub repository and disabling GitHub Pages.
-This requires additional custom configuration.
-In the private setting, the manuscript HTML and PDF outputs are automatically generated when the manuscript source is updated, but only GitHub users granted access to the repository are able to download them.
-
 ### Timestamping
 
 The idea of the "priority of discovery" is important to science, and Vale and Hyman discuss the importance of both disclosure and validation [@doi:10.7554/eLife.16931].

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -129,6 +129,8 @@ Although we developed Manubot with collaborative writing in mind, it can also be
 Authors may choose to make their changes directly to the `master` branch, forgoing pull requests and reviews.
 This workflow retains many of Manubot's benefits, such as transparent history, automation, and allowing outside contributors to propose changes.
 In cases where outside contributions are unwanted, authors can disable pull requests on GitHub.
+It is also possible to use Manubot on a private GitHub repository.
+Private manuscripts require some additional customization to disable GitHub Pages and may require a paid continuous integration plan.
 See the [existing manuscripts] for examples of the range of contribution workflows and Manubot use cases.
 
 ## Manubot features

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -103,6 +103,9 @@ This feedback was discussed in [GH137](https://github.com/greenelab/meta-review/
 > Is it possible to use manubot on a private GitHub repository?
 I'm pretty sure some people would be interested in using manubot but probably would not use it for open editing.
 
+Yes, we confirmed that Manubot works with a private GitHub repository and described this in the `Continuous publication` section.
+This possibility was discussed in [GH138](https://github.com/greenelab/meta-review/issues/138) and addressed in [GH192](https://github.com/greenelab/meta-review/pull/192).
+
 > In the discussion, to what extent a contributor can only use the GitHub interface (text editor + automated PR)?
 Would not that be a way to lower the technical entry level for contributors?
 

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -103,7 +103,10 @@ This feedback was discussed in [GH137](https://github.com/greenelab/meta-review/
 > Is it possible to use manubot on a private GitHub repository?
 I'm pretty sure some people would be interested in using manubot but probably would not use it for open editing.
 
-We confirmed that Manubot works with a private GitHub repository and described this in the `Continuous publication` section.
+We confirmed that is possible to use Manubot for a private manuscript by using a private GitHub repository and optionally disabling GitHub Pages.
+This requires additional custom configuration.
+In the private setting, the manuscript HTML and PDF outputs are automatically generated when the manuscript source is updated, but only GitHub users granted access to the repository are able to download them.
+
 This possibility was discussed in [GH138](https://github.com/greenelab/meta-review/issues/138) and addressed in [GH192](https://github.com/greenelab/meta-review/pull/192).
 We created [manubot/rootstock#205](https://github.com/manubot/rootstock/pull/205) to update the Rootstock setup documentation to explain how to use Manubot with a private repository.
 

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -103,8 +103,9 @@ This feedback was discussed in [GH137](https://github.com/greenelab/meta-review/
 > Is it possible to use manubot on a private GitHub repository?
 I'm pretty sure some people would be interested in using manubot but probably would not use it for open editing.
 
-Yes, we confirmed that Manubot works with a private GitHub repository and described this in the `Continuous publication` section.
+We confirmed that Manubot works with a private GitHub repository and described this in the `Continuous publication` section.
 This possibility was discussed in [GH138](https://github.com/greenelab/meta-review/issues/138) and addressed in [GH192](https://github.com/greenelab/meta-review/pull/192).
+We created [manubot/rootstock#205](https://github.com/manubot/rootstock/pull/205) to update the Rootstock setup documentation to explain how to use Manubot with a private repository.
 
 > In the discussion, to what extent a contributor can only use the GitHub interface (text editor + automated PR)?
 Would not that be a way to lower the technical entry level for contributors?


### PR DESCRIPTION
Closes #138

WIP until the discussion in #138 with @vsmalladi is resolved.

I'm imaging a workflow where the user has a private repository and disables GitHub Pages without modifying the build script or anything else.  In that case, they could obtain the HTML and PDF from the `gh-pages` branch.  They could view the PDF on GitHub but not the HTML, which would have to be viewed locally.