### PR TITLE
Describe GitHub issues for peer review

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -114,6 +114,10 @@ As of {{creation_date_pretty}}, the Deep Review repository accumulated {{total_c
 The notebook to generate this figure can be [interactively launched using Binder](https://mybinder.org/v2/gh/greenelab/meta-review/binder?filepath=analyses/deep-review-contrib/02.contrib-viz.ipynb) [@doi:10.25080/Majora-4af1f417-011], enabling users to explore alternative visualizations or analyses of the source data.
 ](images/deep-review-contribution-ridge.svg){#fig:contrib width="100%" .white}
 
+GitHub issues and even pull requests can also be used for formal peer review by independent or journal-selected reviewers.
+A reviewer conducting open peer review can create issues using their own GitHub account.
+Alternatively, a reviewer can post feedback with a pseudonymous GitHub account or have a trusted third party such as a journal editor post their comments anonymously.
+
 ## Manubot features
 
 Manubot is a system for writing scholarly manuscripts via GitHub.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -114,9 +114,11 @@ As of {{creation_date_pretty}}, the Deep Review repository accumulated {{total_c
 The notebook to generate this figure can be [interactively launched using Binder](https://mybinder.org/v2/gh/greenelab/meta-review/binder?filepath=analyses/deep-review-contrib/02.contrib-viz.ipynb) [@doi:10.25080/Majora-4af1f417-011], enabling users to explore alternative visualizations or analyses of the source data.
 ](images/deep-review-contribution-ridge.svg){#fig:contrib width="100%" .white}
 
-GitHub issues and even pull requests can also be used for formal peer review by independent or journal-selected reviewers.
-A reviewer conducting open peer review can create issues using their own GitHub account.
+GitHub issues can also be used for formal peer review by independent or journal-selected reviewers.
+A reviewer conducting open peer review can create issues using their own GitHub account, as [one reviewer](https://github.com/greenelab/meta-review/issues/124) did for this manuscript.
 Alternatively, a reviewer can post feedback with a pseudonymous GitHub account or have a trusted third party such as a journal editor post their comments anonymously.
+Authors can elect to respond to reviews in the GitHub issues or a public [response letter](https://github.com/greenelab/meta-review/blob/813f461fe719d8fe7bcda78871cfad106f83dfe7/content/response-to-reviewers.md), creating open peer review.
+** TODO: update `response-to-reviewers.md` URL once it is finalized **
 
 ## Manubot features
 

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -108,6 +108,11 @@ Would not that be a way to lower the technical entry level for contributors?
 
 > Would it be possible for a (anonymous) reviewer to use the workflow to do the actual review?
 
+It is possible to use issues to coordinate peer review, as [Reviewer 3 did](https://github.com/greenelab/meta-review/issues/124) for this manuscript.
+We updated the manuscript to present this possibility for open peer review.
+Anonymous journal peer review requires an editor to post the reviewers' comments.
+We discussed this in [GH140](https://github.com/greenelab/meta-review/issues/140) and edited the manuscript in [GH193](https://github.com/greenelab/meta-review/pull/193).
+
 > Could you elaborate a bit on the potential limitations of the markdown language?
 Did you encounter some difficulties in referencing figures or tables?
 


### PR DESCRIPTION
Closes #140.

The GitHub [account terms](https://help.github.com/en/articles/github-terms-of-service#b-account-terms) do not require a real name but do state

> you may not have more than one free Account

Therefore, I stopped short of recommending reviewers create a new pseudonymous account for peer review.