### PR TITLE
Reduce span of hyperlinked text

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -10,7 +10,7 @@ Based on our experience leading a recent open review [@tag:techblog-manubot], we
 Our review manuscript [@doi:10.1098/rsif.2017.0387] was code-named the Deep Review and surveyed deep learning's role in biology and precision medicine, a research area undergoing explosive growth.
 We initiated the Deep Review in August 2016 by creating a GitHub repository (<https://github.com/greenelab/deep-review>) to coordinate and manage contributions.
 GitHub is a platform designed for collaborative software development that is adaptable for collaborative writing.
-From the start, we made the GitHub repository public under a [Creative Commons Attribution 4.0 International (CC BY 4.0) license](https://github.com/greenelab/deep-review/blob/master/LICENSE.md).
+From the start, we made the GitHub repository public under a Creative Commons Attribution License ([CC BY 4.0](https://github.com/greenelab/deep-review/blob/master/LICENSE.md "Creative Commons Attribution 4.0 International License")).
 We encouraged anyone interested to contribute by proposing changes or additions.
 Although we invited some specific experts to participate, most authors discovered the manuscript organically through conferences or social media, deciding to contribute without solicitation.
 In total, the Deep Review attracted {{deep_review_authors}} authors, who were not determined in advance, from 20 different institutions in less than two years.

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -167,7 +167,7 @@ We discussed this comment in [GH143](https://github.com/greenelab/meta-review/pu
 > `we made the GitHub repository public under a Creative Commons Attribution License.` → The link points to CC-BY 4.0 International, it would be good to have this information in the name of the link (or we have to click to check which kind CC you used).
 
 We now state the full license name in the link text: `Creative Commons Attribution 4.0 International (CC BY 4.0) license`.
-See [GH145](https://github.com/greenelab/meta-review/issues/145) and [GH154](https://github.com/greenelab/meta-review/pull/154) for the discussion and edits.
+We noted this issue in [GH145](https://github.com/greenelab/meta-review/issues/145) and resolved it in [GH154](https://github.com/greenelab/meta-review/pull/154) and [GH199](https://github.com/greenelab/meta-review/pull/199).
 
 > `they lack sufficient features for managing a collaborative editing` → This is a bit of an overstatemeent because these tools are used daily by a lot of people to do just that.
 I agree on the second part on the 'precise credit' aspect but as the sentence is currently written, you seem to imply that even collaborative editing is not possible.


### PR DESCRIPTION
[Prior](https://greenelab.github.io/meta-review/v/675980c23332d6a62b8849c455ebc7915d6683e0/#introduction) to this PR, the amount of text linked for the license was a bit excessive IMO:

> ![image](https://user-images.githubusercontent.com/1117703/55823690-48a54980-5ad0-11e9-9c31-72bc87e640bc.png)

I believe this should still address the reviewer comment in https://github.com/greenelab/meta-review/issues/145.