### PR TITLE
Add Bookdown example

### DIFF
--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -417,7 +417,7 @@ Existing authors continue to discuss new literature, [creating a living document
 Manubot provides an ideal platform for perpetual reviews [@arxiv:1502.01329; @tag:livecoms].
 
 Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog-brown].
-Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing, and Bookdown has been used for community-authored books [@doi:10.12688/f1000research.16516.1].
+Pandoc Scholar [@doi:10.7717/peerj-cs.112] and Bookdown [@doi:10.1201/9781315204963], which has been used for open writing [@doi:10.12688/f1000research.16516.1], both extend traditional Markdown to better support publishing.
 Examples of continuous integration to automate manuscript generation include [gh-publisher](https://github.com/ewanmellor/gh-publisher) and [jekyll-travis](https://github.com/mfenner/jekyll-travis), which was used to produce a [continuously published webpage](http://book.openingscience.org/) for the Opening Science book [@url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/; @doi:10.1007/978-3-319-00026-8].
 Binder [@doi:10.25080/Majora-4af1f417-011], Distill journal articles [@doi:10.23915/distill.00010], Idyll [@tag:idyll], and Stencila [@tag:stencila; @tag:elife-repro-article] support manuscripts with interactive graphics and close integration with the underlying code.
 As an open source project, Manubot can be extended to adopt best practices from these other emerging platforms.

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -417,7 +417,7 @@ Existing authors continue to discuss new literature, [creating a living document
 Manubot provides an ideal platform for perpetual reviews [@arxiv:1502.01329; @tag:livecoms].
 
 Concepts for the future of scholarly publishing extend beyond collaborative writing [@doi:10.22541/au.149693987.70506124; @tag:techblog-brown].
-Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing.
+Bookdown [@doi:10.1201/9781315204963] and Pandoc Scholar [@doi:10.7717/peerj-cs.112] both extend traditional Markdown to better support publishing, and Bookdown has been used for community-authored books [@doi:10.12688/f1000research.16516.1].
 Examples of continuous integration to automate manuscript generation include [gh-publisher](https://github.com/ewanmellor/gh-publisher) and [jekyll-travis](https://github.com/mfenner/jekyll-travis), which was used to produce a [continuously published webpage](http://book.openingscience.org/) for the Opening Science book [@url:http://blog.martinfenner.org/2014/03/10/continuous-publishing/; @doi:10.1007/978-3-319-00026-8].
 Binder [@doi:10.25080/Majora-4af1f417-011], Distill journal articles [@doi:10.23915/distill.00010], Idyll [@tag:idyll], and Stencila [@tag:stencila; @tag:elife-repro-article] support manuscripts with interactive graphics and close integration with the underlying code.
 As an open source project, Manubot can be extended to adopt best practices from these other emerging platforms.


### PR DESCRIPTION
This Bookdown example is relevant and worth mentioning somewhere.  This may not be the ideal location or phrasing.

https://github.com/Bioconductor/BiocWorkshops is the GitHub repository for the collaborative book.