### PR TITLE
Fix incorrect DOI in manual references

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -8,7 +8,7 @@ With Manubot, manuscripts are written in Markdown and stored in a Git repository
 By hosting manuscript repositories publicly, such as on GitHub, multiple authors can simultaneously propose and review changes.
 A cloud service automatically evaluates proposed changes to catch errors.
 Publication with Manubot is continuous:
-When a manuscript's source changes, the rendered outputs are rebuilt and republished to a web page.
+When a manuscript's source changes, the rendered outputs are rebuilt and republished to a webpage.
 Manubot automates bibliographic tasks by implementing citation by identifier, where users cite persistent identifiers (e.g. DOIs, PubMed IDs, ISBNs, URLs), whose metadata is then retrieved and converted to a user-specified style.
 Manubot modernizes publishing to align with the ideals of open science by making it transparent, reproducible, immediate, versioned, collaborative, and free of charge.
 

--- a/content/02.main-text.md
+++ b/content/02.main-text.md
@@ -20,7 +20,7 @@ However, inviting wide authorship brought many technical and social challenges s
 The manuscript writing process we developed using the Markdown language, the GitHub platform, and our new Manubot tool for automating manuscript generation addresses these challenges.
 
 Manubot supports citations by adding a persistent identifier like a Digital Object Identifier (DOI) or PubMed Identifier (PMID) directly in the text so that large groups of authors do not have to coordinate reference lists.
-When text is changed, Manubot automatically updates the manuscript's web page so that all authors can read and edit from the latest version.
+When text is changed, Manubot automatically updates the manuscript's webpage so that all authors can read and edit from the latest version.
 Because manuscripts are created from GitHub repositories, Manubot supports a workflow where all edits are reviewed and discussed, ensuring that the collaborative text has a cohesive style and message and that authors receive precise credit for their work.
 These and other features support an open collaborative writing process that is not feasible with other writing platforms.
 

--- a/content/manual-references-2019-06-11.json
+++ b/content/manual-references-2019-06-11.json
@@ -27656,7 +27656,7 @@
       ]
     },
     "abstract": "Report detailing work done in the Greene Lab at the University of Pennsylvania for the Summer of 2017. Sparse mat.53465rix implementation of degree-weighted path count (DWPC) over a heterogeneous network of biomedical information. Summer research conducted as part of the Penn Vagelos Scholars Program in Molecular Life Science (MLS).",
-    "DOI": "10.6084/m9.figshare77",
+    "DOI": "10.6084/m9.figshare.5346577",
     "publisher": "Figshare",
     "title": "Vagelos Report Summer 2017",
     "URL": "https://doi.org/gbr3pf",

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -64,7 +64,7 @@
       ]
     },
     "abstract": "Report detailing work done in the Greene Lab at the University of Pennsylvania for the Summer of 2017. Sparse mat.53465rix implementation of degree-weighted path count (DWPC) over a heterogeneous network of biomedical information. Summer research conducted as part of the Penn Vagelos Scholars Program in Molecular Life Science (MLS).",
-    "DOI": "10.6084/m9.figshare77",
+    "DOI": "10.6084/m9.figshare.5346577",
     "publisher": "Figshare",
     "title": "Vagelos Report Summer 2017",
     "URL": "https://doi.org/gbr3pf"


### PR DESCRIPTION
Presumably this was a typo at some point.

Refs https://github.com/greenelab/meta-review/issues/244#issuecomment-505199526